### PR TITLE
Beginning of my tweaks, bugfix:exports_cfg

### DIFF
--- a/src/ha-cluster/InitializeCorosync.sh
+++ b/src/ha-cluster/InitializeCorosync.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+# This script will attempt to initialize the corosync settings for LizardFS
+# The SetupCorosyncServices.sh script should be used first to prep them.
+# This only needs to be run on one member of the corosync cluster.
+
+if [ ! `pgrep corosync` ] || [ ! `pgrep pacemaker` ] ; then
+ echo " The corosync and/or pacemaker services do not appear to be running."
+ echo " /etc/init.d/corosync start ; sleep 1 ; /etc/init.d/pacemaker start # To start the services"
+ echo " # Pausing so you can break ^C and correct this problem" ; read foo
+fi
+
+if [ ! $FailoverIP ] ; then
+ echo " You must set FailoverIP to the appropriate IP, such as 10.10.10.FloatIPLastOctet"
+ echo " export FailoverIP=10.10.10.?? # Pausing so you can break ^C and correct this problem" ; read foo
+else echo " FailoverIP is set to $FailoverIP" ; fi
+
+if [ ! `which crm` ] ; then
+ echo " The crm command does not appear to be available, maybe install crmsh" ; read foo ; exit
+else echo " The crm command is available, continuing..." ; fi
+
+echo -e "property stonith-enabled=false\ncommit"   | crm configure
+	echo " Disabled STONITH, should look into ability to enable. "
+echo -e "property no-quorum-policy=ignore\ncommit" | crm configure
+	echo " Disable quorum handling, should look into ability to enable. "
+echo -e "primitive Failover-IP ocf:heartbeat:IPaddr2 params ip=$FailoverIP cidr_netmask=24 op monitor interval=1s\ncommit" | crm configure
+	echo " Added VirtualIP"
+crm configure rsc_defaults resource-stickiness=100
+	echo " Changed the resource stickiness to prevent unnecessary movement of resources "
+primitiv='primitive lizardfs-master ocf:lizardfs:metadataserver params master_cfg="/etc/mfs/mfsmaster.cfg"' # Define the primitive for lizardfs-master 
+monitor='op monitor role="Master" interval="1s" timeout="30" op monitor role="Slave" interval="2s" timeout="40"' # Primitives monitor settings 
+transit='op start interval="0" timeout="1800" op stop interval="0" timeout="1800" op promote interval="0" timeout="1800" op demote interval="0" timeout="1800"' # Primitives transitions. 
+echo -e $primitiv $monitor $transit | crm configure
+	echo " created the Primitive with it's monitor and transition settings. "
+echo -e 'ms lizardfs-ms lizardfs-master meta master-max="1" master-node-max="1" clone-node-max="1" notify="true" target-role="Master"' | crm configure
+	echo " Setup Primitive "
+echo -e 'colocation ip-with-master inf: Failover-IP lizardfs-ms:Master' | crm configure
+	echo " Define how the IP and Master primitives relate "
+echo -e 'order master-after-ip inf: Failover-IP:start lizardfs-ms:promote' | crm configure
+	echo " Define how the IP and master will transition. "
+
+echo
+echo " Finished Initializing corosync settings for LizardFS services and Failover-IP address"
+echo " /etc/init.d/pacemaker stop ; /etc/init.d/corosync stop # Stop the managed service by pacemaker and then corosync. "
+echo " /etc/init.d/corosync start ; sleep 1 ; /etc/init.d/pacemaker start # Startup the corosync and pacemaker services. "
+echo "  While it should be safe to run this multiple times it will likely have no effect after the initial run."
+echo " #Run# rm -rfv /var/lib/pengine/* /var/lib/heartbeat/crm/* # To Destroy the old cluster information and start over. "
+
+##

--- a/src/ha-cluster/README
+++ b/src/ha-cluster/README
@@ -15,4 +15,6 @@ live mfs-master instance and a shadow master. [1]: http://clusterlabs.org/doc/
 
 
 https://github.com/lizardfs/lizardfs/issues/621#issuecomment-344578582
-Yes. My useful information is that the lizardfs-admin tool is the human, scriptable, programmable interface to communicate with the master.  It works perfectly. There is nothing wrong with it. That IS is answer.
+Yes. My useful information is that the lizardfs-admin tool is the human,
+scriptable, programmable interface to communicate with the master.
+It works perfectly. There is nothing wrong with it. That IS is answer.

--- a/src/ha-cluster/README
+++ b/src/ha-cluster/README
@@ -1,76 +1,13 @@
-This directory contains an OCF resource agent, for managing failover between a
-live mfs-master instance and a shadow master.
+Please see:
 
-To use this, you will need a cluster resource manager like Pacemaker.  Follow
-the instructions for setting up a basic cluster found in Clusters from
-Scratch[1], which has several variants depending on your distro and exactly
-what set of versions and frontend packages your distro has, up though chapter
-5, Creating and Active/Passive cluster.  This will show you how to configure a
-basic cluster setup, and a mobile IP that will move to whichever node is the
-current master, so that clients don't have to be part of the cluster and
-receive notification when the master changes, but simply continue to contact
-the same IP.
+* This regarding corosync/pacemaker tweaks for proper debian useage:
+https://github.com/4Dolio/lizardfs/blob/4Dolio-corosync-ocf-metadataserver-patch-1/src/ha-cluster/SetupCorosyncServices.sh
 
-Ensure that you have mfsmaster, lizardfs-probe, and the resource agent installed
-on all machines that you want to run master or shadow master servers on.
+* This regarding instantiation of corosync to support a LizardFS master cluster:
+https://github.com/4Dolio/lizardfs/blob/4Dolio-corosync-ocf-metadataserver-patch-1/src/ha-cluster/InitializeCorosync.sh
 
-Once Corosync and Pacemaker are configured, and you have a working cluster
-with an IP resource that you can bounce around, you can add a LizardFS
-master/slave pair as follows.  This is using the configuration syntax of
-crmsh, which I've found works best on Ubuntu, though the syntax for pcs will
-be fairly similar:
+* See also discussions at:
+https://github.com/lizardfs/lizardfs/issues/598#issuecomment-334202503
 
-$ crm configure primitive lizardfs-master ocf:lizardfs:mfsmaster \
-    op monitor role="Master" interval="10s" \
-    op monitor role="Slave" interval="20s"
-
-where Failover-IP is IP address of bouncing master server that shall be used
-by all master's clients.
-
-$ crm configure ms lizardfs-ms lizardfs-master \
-    meta master-max="1" master-node-max="1" clone-max="N" clone-node-max="1" \
-    notify="true" target-role="Master"
-
-where N is number of nodes with lizardfs-master installed.
-Alternatively one can skip all node/master count options entirely, so command becomes:
-
-$ crm configure ms lizardfs-ms lizardfs-master \
-    meta notify="true" target-role="Master"
-
-Note that most of the config options don't need to be provided; we supply
-sensible defaults.  The "ms" (master-slave) options all do need to be provided,
-however.
-
-Now you should have two resources, and if you have at least two servers in
-your Pacemaker cluster, you should see one running on each of two servers.
-
-To make this truly useful, we want to have the cluster IP (which you should have
-set up earlier if you followed the Clusters from Scratch instructions) follow
-the master around.  We want it to always be on the server that the master is on,
-and come up after the master has come up.  We can achieve that with:
-
-$ crm configure colocation ip-with-master inf: ClusterIP lizardfs-ms:Master
-$ crm configure order ip-after-master inf: lizardfs-ms:promote ClusterIP:start
-
-You can now play around; bring them all down to slave states with the
-following:
-
-$ crm resource demote lizardfs-clone
-
-And back with:
-
-$ crm resource promote lizardfs-clone
-
-Or you can temporarily take one node offline, moving all resources from it:
-
-$ crm node standby machine-1
-
-And later:
-
-$ crm node online machine-1
-
-Now just configure your chunk servers, cgi server, and clients to point at
-the ClusterIP that you configured, and they should all fail over gracefully
-to the current master server, whichever that is.
-
-[1]: http://clusterlabs.org/doc/
+This directory contains an OCF resource agent,for managing failover between a
+live mfs-master instance and a shadow master. [1]: http://clusterlabs.org/doc/

--- a/src/ha-cluster/README
+++ b/src/ha-cluster/README
@@ -11,10 +11,3 @@ https://github.com/lizardfs/lizardfs/issues/598#issuecomment-334202503
 
 This directory contains an OCF resource agent,for managing failover between a
 live mfs-master instance and a shadow master. [1]: http://clusterlabs.org/doc/
-
-
-
-https://github.com/lizardfs/lizardfs/issues/621#issuecomment-344578582
-I am not trolling. My useful information is that the lizardfs-admin tool is
-the human, scriptable, programmable interface to communicate with the master.
-It works perfectly. There is nothing wrong with it. That IS answer.

--- a/src/ha-cluster/README
+++ b/src/ha-cluster/README
@@ -11,3 +11,8 @@ https://github.com/lizardfs/lizardfs/issues/598#issuecomment-334202503
 
 This directory contains an OCF resource agent,for managing failover between a
 live mfs-master instance and a shadow master. [1]: http://clusterlabs.org/doc/
+
+
+
+https://github.com/lizardfs/lizardfs/issues/621#issuecomment-344578582
+Yes. My useful information is that the lizardfs-admin tool is the human, scriptable, programmable interface to communicate with the master.  It works perfectly. There is nothing wrong with it. That IS is answer.

--- a/src/ha-cluster/README
+++ b/src/ha-cluster/README
@@ -15,6 +15,6 @@ live mfs-master instance and a shadow master. [1]: http://clusterlabs.org/doc/
 
 
 https://github.com/lizardfs/lizardfs/issues/621#issuecomment-344578582
-Yes. My useful information is that the lizardfs-admin tool is the human,
-scriptable, programmable interface to communicate with the master.
+I am not trolling. My useful information is that the lizardfs-admin tool is
+the human, scriptable, programmable interface to communicate with the master.
 It works perfectly. There is nothing wrong with it. That IS answer.

--- a/src/ha-cluster/README
+++ b/src/ha-cluster/README
@@ -17,4 +17,4 @@ live mfs-master instance and a shadow master. [1]: http://clusterlabs.org/doc/
 https://github.com/lizardfs/lizardfs/issues/621#issuecomment-344578582
 Yes. My useful information is that the lizardfs-admin tool is the human,
 scriptable, programmable interface to communicate with the master.
-It works perfectly. There is nothing wrong with it. That IS is answer.
+It works perfectly. There is nothing wrong with it. That IS answer.

--- a/src/ha-cluster/SetupCorosyncServices.sh
+++ b/src/ha-cluster/SetupCorosyncServices.sh
@@ -30,5 +30,6 @@ sed -i 's/START=no/START=yes/' /etc/default/corosync
 grep "ver:\|Required\|Default\|addr:\|START" /etc/init.d/pacemaker /etc/default/corosync /etc/corosync/corosync.conf
 
 echo " You should run corosync-keygen on your first node to generate an /etc/corosync/authkey which should be coppied to all other nodes."
+echo " This process you just completed with this script must also be completed on all other member nodes."
 
 ##

--- a/src/ha-cluster/SetupCorosyncServices.sh
+++ b/src/ha-cluster/SetupCorosyncServices.sh
@@ -24,7 +24,6 @@ sed -i 's%echo -n "Starting $desc: "$%echo -n "Starting $desc: " ; sleep 2 # mig
 update-rc.d pacemaker defaults ; update-rc.d corosync defaults # Fix up the default for corosync and pacemaker 
 sed -i 's/mcastaddr: .*/mcastaddr: '$mcastaddr'/' /etc/corosync/corosync.conf # VERIFY THIS IS CORRECT FOR THE INTENDED CLUSTER 
 sed -i 's/^.*mcastaddr: .*/\t\tmcastaddr: '$mcastaddr'/' /etc/corosync/corosync.conf # Deb 8.5-ish has this commented out by default
-sed -i 's/bindnetaddr: 127.0.0.1/bindnetaddr: '$bindnetaddr'/' /etc/corosync/corosync.conf # this should match the network on which the floating IP will live. 
 sed -i 's/bindnetaddr: .*/bindnetaddr: '$bindnetaddr.0/ /etc/corosync/corosync.conf # this should match the network on which the floating IP will live.
 sed -i 's/START=no/START=yes/' /etc/default/corosync 
 

--- a/src/ha-cluster/SetupCorosyncServices.sh
+++ b/src/ha-cluster/SetupCorosyncServices.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+# This script will attempt to "fix" corosync and pacemaker services on Debian distributions
+# to work properly with the LizardFS metadataserver OCF Script and Floating FailoverIP
+
+if [ `dpkg -l | grep -c corosync` -lt 1 ]  ; then echo " corosync does not appear to be installed"  ; fi
+if [ `dpkg -l | grep -c pacemaker` -lt 1 ] ; then echo " pacemaker does not appear to be installed" ; fi
+if [ ! $mcastaddr ] ; then
+ echo " You must set mcastaddr to the appropriate IP, such as 226.94.1.FloatIPLastOctet"
+ echo " export mcastaddr=226.94.1.?? # Pausing so you can break ^C and correct this problem" ; read foo
+else echo " mcastaddr is set to $mcastaddr" ; fi
+
+if [ ! $FailoverIP ] ; then
+ echo " You must set FailoverIP to the appropriate IP, such as 10.10.10.FloatIPLastOctet"
+ echo " export FailoverIP=10.10..?? # Pausing so you can break ^C and correct this problem" ; read foo
+else echo " FailoverIP is set to $FailoverIP" ; fi
+bindnetaddr=$( echo $FailoverIP | cut -f1-3 -d\. )
+echo " bindnetaddr is set to $bindnetaddr.0"
+
+sed -i 's/^.*ver:.*/ \tver: 1/' /etc/corosync/corosync.conf # This makes pacemaker behave as an independent service 
+sed -i 's/^# Required-Stop:.*/# Required-Stop:\t$network corosync/' /etc/init.d/pacemaker # Pacemaker needs to know it must stop before corosync can stop 
+sed -i 's/^# Default-Start:.*/# Default-Start:\t2 3 4 5/' /etc/init.d/pacemaker # Since pacemaker is an independent service we should start 
+sed -i 's/^# Default-Stop:.*/# Default-Stop: \t0 1 6/' /etc/init.d/pacemaker # and stop it. 
+sed -i 's%echo -n "Starting $desc: "$%echo -n "Starting $desc: " ; sleep 2 # might fail to start if corosync also started recently%' /etc/init.d/pacemaker
+update-rc.d pacemaker defaults ; update-rc.d corosync defaults # Fix up the default for corosync and pacemaker 
+sed -i 's/mcastaddr: .*/mcastaddr: '$mcastaddr'/' /etc/corosync/corosync.conf # VERIFY THIS IS CORRECT FOR THE INTENDED CLUSTER 
+sed -i 's/bindnetaddr: 127.0.0.1/bindnetaddr: '$bindnetaddr'/' /etc/corosync/corosync.conf # this should match the network on which the floating IP will live. 
+sed -i 's/bindnetaddr: .*/bindnetaddr: '$bindnetaddr.0/ /etc/corosync/corosync.conf # this should match the network on which the floating IP will live.
+sed -i 's/START=no/START=yes/' /etc/default/corosync 
+
+grep "ver:\|Required\|Default\|addr:\|START" /etc/init.d/pacemaker /etc/default/corosync /etc/corosync/corosync.conf
+
+echo " You should run corosync-keygen on your first node to generate an /etc/corosync/authkey which should be coppied to all other nodes."
+
+##

--- a/src/ha-cluster/SetupCorosyncServices.sh
+++ b/src/ha-cluster/SetupCorosyncServices.sh
@@ -23,6 +23,7 @@ sed -i 's/^# Default-Stop:.*/# Default-Stop: \t0 1 6/' /etc/init.d/pacemaker # a
 sed -i 's%echo -n "Starting $desc: "$%echo -n "Starting $desc: " ; sleep 2 # might fail to start if corosync also started recently%' /etc/init.d/pacemaker
 update-rc.d pacemaker defaults ; update-rc.d corosync defaults # Fix up the default for corosync and pacemaker 
 sed -i 's/mcastaddr: .*/mcastaddr: '$mcastaddr'/' /etc/corosync/corosync.conf # VERIFY THIS IS CORRECT FOR THE INTENDED CLUSTER 
+sed -i 's/^.*mcastaddr: .*/\t\tmcastaddr: '$mcastaddr'/' /etc/corosync/corosync.conf # Deb 8.5-ish has this commented out by default
 sed -i 's/bindnetaddr: 127.0.0.1/bindnetaddr: '$bindnetaddr'/' /etc/corosync/corosync.conf # this should match the network on which the floating IP will live. 
 sed -i 's/bindnetaddr: .*/bindnetaddr: '$bindnetaddr.0/ /etc/corosync/corosync.conf # this should match the network on which the floating IP will live.
 sed -i 's/START=no/START=yes/' /etc/default/corosync 

--- a/src/ha-cluster/SetupCorosyncServices.sh
+++ b/src/ha-cluster/SetupCorosyncServices.sh
@@ -4,16 +4,16 @@
 
 if [ `dpkg -l | grep -c corosync` -lt 1 ]  ; then echo " corosync does not appear to be installed"  ; fi
 if [ `dpkg -l | grep -c pacemaker` -lt 1 ] ; then echo " pacemaker does not appear to be installed" ; fi
-if [ ! $mcastaddr ] ; then
+if [ ! $mcastaddr ] ; then # for corosync use
  echo " You must set mcastaddr to the appropriate IP, such as 226.94.1.FloatIPLastOctet"
  echo " export mcastaddr=226.94.1.?? # Pausing so you can break ^C and correct this problem" ; read foo
 else echo " mcastaddr is set to $mcastaddr" ; fi
 
-if [ ! $FailoverIP ] ; then
+if [ ! $FailoverIP ] ; then # for lizardfs cluster master address
  echo " You must set FailoverIP to the appropriate IP, such as 10.10.10.FloatIPLastOctet"
  echo " export FailoverIP=10.10..?? # Pausing so you can break ^C and correct this problem" ; read foo
 else echo " FailoverIP is set to $FailoverIP" ; fi
-bindnetaddr=$( echo $FailoverIP | cut -f1-3 -d\. )
+bindnetaddr=$( echo $FailoverIP | cut -f1-3 -d\. ) # Assumes a Class C block
 echo " bindnetaddr is set to $bindnetaddr.0"
 
 sed -i 's/^.*ver:.*/ \tver: 1/' /etc/corosync/corosync.conf # This makes pacemaker behave as an independent service 

--- a/src/ha-cluster/metadataserver.in
+++ b/src/ha-cluster/metadataserver.in
@@ -199,10 +199,12 @@ ocf_log error "#####  : crm resource cleanup lizardfs-ms # clear all cluster err
 ocf_log error "#####"
 ocf_log error "##### If this node crashed try: rm ${master_lock} && crm resource cleanup lizardfs-ms"
 ocf_log error "#####"
+ocf_log error "##### As an absolute last resort if the cluster metadata version is newer than anything you have,"
+ocf_log error "##### Reset what the cluster believes the metadata version is so you can use with what you have."
+ocf_log error "##### ${HA_SBIN_DIR}/crm_attribute --lifetime=forever --type=crm_config --name=${metadata_version_attribute_name} --update=0"
+ocf_log error "##### An alternate option would be to start a master before corosync, that master should reset the clusters version."
+ocf_log error "#####"
 }
-# Consider adding an automated self `crm resource cleanup lizardfs-ms`
-# command once a master does succeed at coming online just after:
-# INFO: LizardFS metadata server promoted successfully
 
 # Utilities
 
@@ -502,19 +504,40 @@ lizardfs_probe() {
 		elif [[ "$probe_results" =~ "ENOTCONN (Transport endpoint is not connected)" ]]\
 		 && [[ ! -z `pgrep -f "initial-personality=master start"` ]] ; then
 			echo -e "master\tstopping"
-# Can not determine the difference between stopping and starting initial master service.
-# It is not a problem that we can not tell them apart, both are valid states which we wait on.
+## Can not determine the difference between stopping and starting initial master service, which
+## is not a problem that we can not tell them apart, both are valid states which we wait on.
 #			echo -e "master\tstarting"
+## When the master dumps metadata to disk at the top of each hour it may stop responding for a moment.
+## This has been observed with metadata.mfs > 8GB , but not with metadata.mfs < 1.6G.
+## Test this with `echo -n "${admin_password}" | lizardfs-admin save-metadata "${host}" ${matocl_port}`
+## Attempting to count the processes for the forked dumping process does not seem to work:
+#		elif [[ "$probe_results" =~ "read data from socket: timeout" ]]\
+#		 && [[ `pgrep -cf "initial-personality"` -gt 1 ]] ; then
+#			echo -e "master\tdumping"
+## To prevent it from being demoted, attempt the probe one or two more times before giving up.
+## probes time-out in ~5~7 sec, so only probe twice with 3 second of sleep. monitor will timeout in 20.
+		elif [[ "$probe_results" =~ "read data from socket: timeout" ]]\
+		 && [[ ! -z `pgrep -f "ha-cluster-managed"` ]] && [[ -z $retry_probe ]] ; then
+			msg="read data from socket: timeout. Trying to probe again"
+			ocf_log error "$msg" ; test $debug && ocf_log notice "$msg"
+			retry_probe=1 ; sleep 3 ; lizardfs_probe
+## probes times out in ~5~7 sec * 3 = 15~21 sec + sleep, corosync default timeout is 20 seconds.
+## Trying a third probe attempt might exceed the monitor operation timeout, which could be increased...
+#		elif [[ "$probe_results" =~ "read data from socket: timeout" ]]\
+#		 && [[ ! -z `pgrep -f "ha-cluster-managed"` ]] && [[ -z $retry_probe_again ]] ; then
+#			msg="read data from socket: timeout. Trying to probe one last time"
+#			ocf_log error "$msg" ; test $debug && ocf_log notice "$msg"
+#			retry_probe_again=1 ; lizardfs_probe
+## After retrying the probe, presume that perhaps the shadow is syncing...
 		elif [[ "$probe_results" =~ "read data from socket: timeout" ]]\
 		 && [[ ! -z `pgrep -f "initial-personality=shadow start"` ]] ; then
 			echo -e "shadow\tsyncing"
-#		elif [[ ! -z `pgrep -f "initial-personality=shadow start"` ]] ; then
-#			echo -e "shadow\tsyncing"
 #		elif [[ "$probe_results" =~ "connection failed, error: ECONNREFUSED (Connection refused)" ]]\
 #		 && [[ ! -z `pgrep -f "initial-personality=shadow start"` ]] ; then
 #			ocf_log error "##### mfsmetarestore -a ; crm resource cleanup lizardfs-ms"
 #			echo -e "master\tunclean"
 ## Attempting to catch the quick stopped master which can only become a shadow or would require mfsmetarestore -a
+## That does not work so instead we use the "promotion to master was prevented by monitor" method
 		else
 			echo -e "unknown\tunknown\t$probe_results"
 		fi
@@ -558,8 +581,7 @@ lizardfs_master_monitor() {
 	ret=$?
 
 	if [ $ret -eq 0 ] ; then
-		# mfsmaster is running, check to see if we're a shadow master or full
-		# master
+		# mfsmaster is running, check to see if we're a shadow master or full master
 		probe_result=$(lizardfs_probe)
 		if [ $? -ne 0 ] ; then
 			msg="failed to query LizardFS master status"
@@ -589,6 +611,7 @@ lizardfs_master_monitor() {
 #				msg="running in master mode starting up."
 #				ocf_log debug "$msg" ; test $debug && ocf_log notice "$msg"
 #				update_master_score ${score_shadow_no_metadata}
+#				return $OCF_RUNNING_MASTER
 #				return $OCF_SUCCESS
 #			;;
 			shadow/stopping)
@@ -619,7 +642,7 @@ lizardfs_master_monitor() {
 					local local_metadata_version=$(get_metadata_version_from_file)
 				fi
 				if [ ${local_metadata_version} -ge ${cluster_metadata_version} ] ; then
-					msg="running in shadow mode, have latest metadata: ${local_metadata_version}"
+					msg="running in shadow mode, have latest metadata: ${local_metadata_version}, can be promoted."
 					ocf_log debug "$msg" ; test $debug && ocf_log notice "$msg"
 					update_master_score ${score_shadow_lastest}
 					if [[ $in_memory ]] ; then
@@ -633,7 +656,7 @@ lizardfs_master_monitor() {
 					update_master_score ${score_shadow_connected}
 					promote_mode="reload"
 				else
-					msg="running in shadow mode, no metadata ${local_metadata_version}."
+					msg="running in shadow mode, no metadata ${local_metadata_version} < ${cluster_metadata_version}."
 					ocf_log debug "$msg" ; test $debug && ocf_log notice "$msg"
 					# Do not promote shadow with no metadata!
 					update_master_score ${score_shadow_no_metadata}

--- a/src/ha-cluster/metadataserver.in
+++ b/src/ha-cluster/metadataserver.in
@@ -484,9 +484,16 @@ lizardfs_probe() {
 		host=$matocl_host
 	fi
 # Error: Can't connect to 127.0.0.1:9421: ENOTCONN (Transport endpoint is not connected)
-## While stopping shadow master, stopping initial master, or starting initial master.
+##	While stopping shadow master, stopping initial master, or starting initial master.
+# Error: Can't connect to 127.0.0.1:9421: ETIMEDOUT (Operation timed out)
+##	While the master service is busy doing snapshots or other things ??
 # Error: Can't read data from socket: timeout
-## While starting shadow master and reintegrating new metadata received from master.
+##	While starting shadow master and reintegrating new metadata received from master.
+# Error: Can't read data from socket: Connection reset by peer
+##	This might also occur when the master service is busy ??
+# Error: connection failed, error: ECONNREFUSED (Connection refused)
+##	Rare, maybe "master\unclean" in need of ocf_log error "##### mfsmetarestore -a ; crm resource cleanup lizardfs-ms"
+
 # Send errors to stdin so we can determine status of service which is not responding to network probes:
 	probe_results=$(lizardfs-admin metadataserver-status --porcelain "${host}" "$matocl_port" 2>&1)
         ret=$?
@@ -505,6 +512,7 @@ lizardfs_probe() {
 ## Can not determine the difference between stopping and starting initial master service, which
 ## is not a problem that we can not tell them apart, both are valid states which we wait on.
 #			echo -e "master\tstarting"
+
 ## When the master dumps metadata to disk at the top of each hour it may stop responding for a moment.
 ## This has been observed with metadata.mfs > 8GB , but not with metadata.mfs < 1.6G.
 ## Test this with `echo -n "${admin_password}" | lizardfs-admin save-metadata "${host}" ${matocl_port}`
@@ -525,26 +533,6 @@ lizardfs_probe() {
 			msg="read data from socket: Connection reset by peer. Trying to probe again"
 			ocf_log error "$msg" ; test $debug && ocf_log notice "$msg"
 			retry_probe=1 ; sleep 3 ; lizardfs_probe
-## probes times out in ~5~7 sec * 3 = 15~21 sec + sleep, corosync default timeout is 20 seconds.
-## Trying a third probe attempt might exceed the monitor operation timeout, which could be increased...
-#		elif [[ "$probe_results" =~ "read data from socket: timeout" ]]\
-#		 && [[ ! -z `pgrep -f "ha-cluster-managed"` ]] && [[ -z $retry_probe_again ]] ; then
-#			msg="read data from socket: timeout. Trying to probe one last time"
-#			ocf_log error "$msg" ; test $debug && ocf_log notice "$msg"
-#			retry_probe_again=1 ; lizardfs_probe
-## After retrying the probe, presume that perhaps the shadow is syncing...
-		elif [[ "$probe_results" =~ "read data from socket: timeout" ]]\
-		 && [[ ! -z `pgrep -f "initial-personality=shadow start"` ]] ; then
-			echo -e "shadow\tsyncing"
-## Might also get Can't read data from socket: Connection reset by peer
-		elif [[ "$probe_results" =~ "read data from socket: Connection reset by peer" ]]\
-		 && [[ ! -z `pgrep -f "initial-personality=shadow start"` ]] ; then
-			echo -e "shadow\tsyncing"
-#		elif [[ "$probe_results" =~ "connection failed, error: ECONNREFUSED (Connection refused)" ]]\
-#		 && [[ ! -z `pgrep -f "initial-personality=shadow start"` ]] ; then
-#			ocf_log error "##### mfsmetarestore -a ; crm resource cleanup lizardfs-ms"
-#			echo -e "master\tunclean"
-## After retrying the probe, presume that perhaps the master is momentarially busy...
 ###metadataserver[8375]: NOTICE: read data from socket: timeout. Trying to probe again
 ###metadataserver[8375]: NOTICE: unexpected output from lizardfs-admin: unknown#011unknown#011Error: Can't read data from socket: timeout
 ###metadataserver[8840]: NOTICE: unexpected output from lizardfs-admin: unknown#011unknown#011Error: Can't connect to 127.0.0.1:9421: ETIMEDOUT (Operation timed out)
@@ -555,14 +543,37 @@ lizardfs_probe() {
 			msg="connect to 127.0.0.1:9421: ETIMEDOUT. Trying to probe again"
 			ocf_log error "$msg" ; test $debug && ocf_log notice "$msg"
 			retry_probe=1 ; sleep 3 ; lizardfs_probe
-# also try to trap timeout as master ( This might prevent actual fault detection )
-		elif [[ "$probe_results" =~ "read data from socket: timeout" ]]\
-		 && [[ ! -z `pgrep -f "initial-personality=master start"` ]] ; then
-			echo -e "master\tbusy"
-# also try to trap ETIMEDOUT as master ( This might prevent actual fault detection )
-		elif [[ "$probe_results" =~ "connect to 127.0.0.1:9421: ETIMEDOUT" ]]\
-		 && [[ ! -z `pgrep -f "initial-personality=master start"` ]] ; then
-			echo -e "master\tbusy"
+
+## probes times out in ~5~7 sec * 3 = 15~21 sec + sleep, corosync default timeout is 20 seconds.
+## Trying a third probe attempt might exceed the monitor operation timeout, which could be increased...
+#		elif [[ "$probe_results" =~ "read data from socket: timeout" ]]\
+#		 && [[ ! -z `pgrep -f "ha-cluster-managed"` ]] && [[ -z $retry_probe_again ]] ; then
+#			msg="read data from socket: timeout. Trying to probe one last time"
+#			ocf_log error "$msg" ; test $debug && ocf_log notice "$msg"
+#			retry_probe_again=1 ; lizardfs_probe
+
+## After retrying the probe, presume that timeout perhaps indicates the master is momentarially busy...
+## This might prevent actual fault detection ??
+## This does not help us if the currently acting master was started as a shadow, so we try with the next test
+#		elif ([[ "$probe_results" =~ "read data from socket: timeout" ]] || [[ "$probe_results" =~ "connect to 127.0.0.1:9421: ETIMEDOUT" ]])\
+#		 && [[ ! -z `pgrep -f "initial-personality=master start"` ]] ; then
+#			echo -e "master\tbusy"
+
+## After retrying the probe, presume that perhaps the shadow is syncing, or the master might be busy...
+## Would love to be able to more precicely determin the difference between these states.
+		elif ([[ "$probe_results" =~ "read data from socket:" ]] || [[ "$probe_results" =~ "connect to 127.0.0.1:9421: E" ]])\
+		 && [[ ! -z `pgrep -f "ha-cluster-managed"` ]] ; then
+			Cluster_Master=$(echo $(crm_mon -1 | grep Masters | cut -f2 -d[ | cut -f1 -d]))
+			MyHostname=$(hostname -s)
+			if [[ "${Cluster_Master}" == "${MyHostname}" ]] ; then
+## This might prevent actual fault detection ??
+# read data from socket: timeout || connect to 127.0.0.1:9421: ETIMEDOUT
+				echo -e "master\tbusy" # The cluster thinks I am the master so believe it if the actual service is to busy to be polled.
+			else 
+# read data from socket: timeout || read data from socket: Connection reset by peer
+				echo -e "shadow\tsyncing" # After retrying the probe, presume that perhaps the shadow is syncing...
+			fi
+
 ## Attempting to catch the quick stopped master which can only become a shadow or would require mfsmetarestore -a
 ## That does not work so instead we use the "promotion to master was prevented by monitor" method
 		else
@@ -628,7 +639,7 @@ lizardfs_master_monitor() {
 				update_master_score ${score_master}
 # type_op will be set to something if we are doing any sort of transition,  In a constantly
 # active cluster setting the metadata version here due to a transition will cause a transition
-# abort or delay and we will end up in an ugly loop where by no action will be attempted.
+# abort or delay and we will end up in an ugly loop where by no actions can actually be attempted.
 				[[ -z ${type_op} ]] && set_metadata_version "${metadata_version}"
 				return $OCF_RUNNING_MASTER
 			;;
@@ -639,13 +650,7 @@ lizardfs_master_monitor() {
 				return $OCF_RUNNING_MASTER
 #				return $OCF_SUCCESS
 			;;
-			master/busy)
-				msg="running in master mode, but busy"
-				ocf_log debug "$msg" ; test $debug && ocf_log notice "$msg"
-#Not if Busy#			update_master_score ${score_master}
-#Not if Busy#			set_metadata_version "${metadata_version}"
-				return $OCF_RUNNING_MASTER
-			;;
+# Do not yet know how to determin this state, which is fine, the above works all the same.
 #			master/starting)
 #				msg="running in master mode starting up."
 #				ocf_log debug "$msg" ; test $debug && ocf_log notice "$msg"
@@ -653,6 +658,13 @@ lizardfs_master_monitor() {
 #				return $OCF_RUNNING_MASTER
 #				return $OCF_SUCCESS
 #			;;
+			master/busy)
+				msg="running in master mode, but might be busy. This Might Fail to Detect Faults."
+				ocf_log debug "$msg" ; test $debug && ocf_log notice "$msg"
+#Not if Busy#			update_master_score ${score_master}
+#Not if Busy#			set_metadata_version "${metadata_version}"
+				return $OCF_RUNNING_MASTER
+			;;
 			shadow/stopping)
 				msg="running in shadow mode and stopping."
 				ocf_log debug "$msg" ; test $debug && ocf_log notice "$msg"
@@ -692,21 +704,25 @@ lizardfs_master_monitor() {
 						promote_mode="restart"
 					fi
 				elif [[ ${local_metadata_version} -gt 0 && ${in_memory} ]] ; then
-					msg="running in shadow mode, latest metadata is not available: ${local_metadata_version} < ${cluster_metadata_version}"
+					metadata_behind=$( expr ${cluster_metadata_version} - ${local_metadata_version} )
+					msg="running in shadow mode, latest metadata is not available: ${local_metadata_version} < ${cluster_metadata_version} (${metadata_behind})"
 					ocf_log debug "$msg" ; test $debug && ocf_log notice "$msg"
 					update_master_score ${score_shadow_connected}
 					promote_mode="reload"
 				else
+					rssize=$( ps h -o rss -p `pgrep mfsmaster` 2>/dev/null )
+					currents_size=$( stat ${master_metadata} -c %s 2>/dev/null )
 					acquired_size=$( stat ${master_metadata}.tmp -c %s 2>/dev/null )
 					previous_size=$( stat ${master_metadata}.1   -c %s 2>/dev/null )
-					msg="running in shadow mode, no metadata ${local_metadata_version} < ${cluster_metadata_version}. Acquiring ${acquired_size}/${previous_size} metadata."
+					msg="running in shadow mode, no metadata ${local_metadata_version} < ${cluster_metadata_version}. RSS ${rssize}. Acquiring ${currents_size}/${acquired_size}/${previous_size} metadata."
 					ocf_log debug "$msg" ; test $debug && ocf_log notice "$msg"
 					# Do not promote shadow with no metadata!
 					update_master_score ${score_shadow_no_metadata}
 #					promote_mode="prevent" # This is already our value...
 # corosync still attempts to promote a shadow with no metadata
 # would be best if it did not even attempt a promotion, but it does.
-# So when the promotion fails we must return $OCF_ERR_PERM # exit and block node from cluster until manual intervention otherwise let it keep trying...
+# So when the promotion fails we must return $OCF_ERR_PERM # exit and block node
+# from cluster until manual intervention otherwise let it keep trying...
                                 
 				fi
 				return $OCF_SUCCESS

--- a/src/ha-cluster/metadataserver.in
+++ b/src/ha-cluster/metadataserver.in
@@ -60,7 +60,7 @@ read_cfg_var() {
 
 # Parameters for this resource agent, with default values
 
-OCF_RESKEY_master_cfg_default=@ETC_PATH@/mfs/mfsmaster.cfg
+OCF_RESKEY_master_cfg_default=/etc/mfs/mfsmaster.cfg
 
 : ${OCF_RESKEY_master_cfg:=$OCF_RESKEY_master_cfg_default}
 
@@ -77,12 +77,12 @@ metadata_version_attribute_name="lizardfs-metadata-version"
 
 failover_ip=$(read_cfg_var ${OCF_RESKEY_master_cfg} MASTER_HOST)
 admin_password=$(read_cfg_var ${OCF_RESKEY_master_cfg} ADMIN_PASSWORD)
-data_dir=$(read_cfg_var ${OCF_RESKEY_master_cfg} DATA_PATH = @DATA_PATH@)
+data_dir=$(read_cfg_var ${OCF_RESKEY_master_cfg} DATA_PATH = /var/lib/mfs)
 matocl_host=$(read_cfg_var ${OCF_RESKEY_master_cfg} MATOCL_LISTEN_HOST = '*')
 matocl_port=$(read_cfg_var ${OCF_RESKEY_master_cfg} MATOCL_LISTEN_PORT = 9421)
-lizardfs_user=$(read_cfg_var ${OCF_RESKEY_master_cfg} WORKING_USER = @DEFAULT_USER@)
-lizardfs_group=$(read_cfg_var ${OCF_RESKEY_master_cfg} WORKING_GROUP = @DEFAULT_GROUP@)
-exports_cfg=$(read_cfg_var ${OCF_RESKEY_master_cfg} WORKING_GROUP = @ETC_PATH@/mfs/mfsexports.cfg)
+lizardfs_user=$(read_cfg_var ${OCF_RESKEY_master_cfg} WORKING_USER = mfs)
+lizardfs_group=$(read_cfg_var ${OCF_RESKEY_master_cfg} WORKING_GROUP = mfs)
+exports_cfg=/etc/mfs/mfsexports.cfg
 
 master_metadata=${data_dir}/metadata.mfs
 master_lock=${data_dir}/metadata.mfs.lock

--- a/src/ha-cluster/metadataserver.in
+++ b/src/ha-cluster/metadataserver.in
@@ -338,6 +338,7 @@ lizardfs_master_promote() {
 				msg="running in shadow mode on cluster with no master, doing full restart"
 				ocf_log debug "$msg" ; test $debug && ocf_log notice "$msg"
 	test $debug && touch $debug_state_change_logs/lfs-`date +\%Y\%m\%d.\%H\%M\%S`-Master1
+				do_cleanup=1 # set variable to let us know to do a cleanup
 				if ! ( ocf_run lizardfs_master stop master && unlink "${master_lock}"\
 				 && ocf_run lizardfs_master start master ) ; then
 					msg="Failed to restart into master mode"
@@ -369,6 +370,16 @@ lizardfs_master_promote() {
 					msg="LizardFS metadata server promoted successfully"
 					ocf_log info "$msg" ; test $debug && ocf_log notice "$msg"
 	test $debug && touch $debug_state_change_logs/lfs-`date +\%Y\%m\%d.\%H\%M\%S`-Promote
+					if [[ "${do_cleanup}" == "1" ]] ; then
+# Adding an automated self `crm resource cleanup lizardfs-ms` command once a master succeeds at coming online.
+						msg="In background sleep and run crm resource cleanup lizardfs-ms # in order to allow shadows to rejoin"
+						ocf_log info "$msg" ; test $debug && ocf_log notice "$msg"
+# There may be some sort of race condition happening.  After a cleanup we sometimes see this error:
+# "WARN: decode_transition_key: Bad UUID" related to one of the numbered lizardfs-master:0 resources.
+# With two cluster members, running the cleanup twice seems to always let the cluster end up clean.
+						( sleep 10;crm resource cleanup lizardfs-ms ) &
+						( sleep 20;crm resource cleanup lizardfs-ms ) &
+					fi
 					return $OCF_SUCCESS
 				;;
 				*)	msg="LizardFS metadata server failed to promote"

--- a/src/ha-cluster/metadataserver.in
+++ b/src/ha-cluster/metadataserver.in
@@ -534,6 +534,25 @@ lizardfs_probe() {
 #		 && [[ ! -z `pgrep -f "initial-personality=shadow start"` ]] ; then
 #			ocf_log error "##### mfsmetarestore -a ; crm resource cleanup lizardfs-ms"
 #			echo -e "master\tunclean"
+## After retrying the probe, presume that perhaps the master is momentarially busy...
+###metadataserver[8375]: NOTICE: read data from socket: timeout. Trying to probe again
+###metadataserver[8375]: NOTICE: unexpected output from lizardfs-admin: unknown#011unknown#011Error: Can't read data from socket: timeout
+###metadataserver[8840]: NOTICE: unexpected output from lizardfs-admin: unknown#011unknown#011Error: Can't connect to 127.0.0.1:9421: ETIMEDOUT (Operation timed out)
+###lrmd: [18628]: info: operation notify[147890] on lizardfs-master:0 for client 18631: pid 8840 exited with return code 0
+# First try and trap the ETIMEDOUT and probe again ( This should prevent eronious demotion when busy )
+		elif [[ "$probe_results" =~ "connect to 127.0.0.1:9421: ETIMEDOUT" ]]\
+		 && [[ ! -z `pgrep -f "ha-cluster-managed"` ]] && [[ -z $retry_probe ]] ; then
+			msg="connect to 127.0.0.1:9421: ETIMEDOUT. Trying to probe again"
+			ocf_log error "$msg" ; test $debug && ocf_log notice "$msg"
+			retry_probe=1 ; sleep 3 ; lizardfs_probe
+# also try to trap timeout as master ( This might prevent actual fault detection )
+		elif [[ "$probe_results" =~ "read data from socket: timeout" ]]\
+		 && [[ ! -z `pgrep -f "initial-personality=master start"` ]] ; then
+			echo -e "master\tbusy"
+# also try to trap ETIMEDOUT as master ( This might prevent actual fault detection )
+		elif [[ "$probe_results" =~ "connect to 127.0.0.1:9421: ETIMEDOUT" ]]\
+		 && [[ ! -z `pgrep -f "initial-personality=master start"` ]] ; then
+			echo -e "master\tbusy"
 ## Attempting to catch the quick stopped master which can only become a shadow or would require mfsmetarestore -a
 ## That does not work so instead we use the "promotion to master was prevented by monitor" method
 		else
@@ -604,6 +623,13 @@ lizardfs_master_monitor() {
 				update_master_score ${score_shadow_no_metadata}
 				return $OCF_RUNNING_MASTER
 #				return $OCF_SUCCESS
+			;;
+			master/busy)
+				msg="running in master mode, but busy"
+				ocf_log debug "$msg" ; test $debug && ocf_log notice "$msg"
+#				update_master_score ${score_master}
+#				set_metadata_version "${metadata_version}"
+				return $OCF_RUNNING_MASTER
 			;;
 #			master/starting)
 #				msg="running in master mode starting up."

--- a/src/ha-cluster/metadataserver.in
+++ b/src/ha-cluster/metadataserver.in
@@ -352,7 +352,39 @@ lizardfs_probe() {
 	else
 		host=$matocl_host
 	fi
-	lizardfs-admin metadataserver-status --porcelain "${host}" "$matocl_port"
+# Send any errors to /tmp/lizardfs_probe for later examination
+	results=`lizardfs-admin metadataserver-status --porcelain "${host}" "$matocl_port" 2>|/tmp/lizardfs_probe`
+# Capture the exit code from this probe command, 0 exited cleanly, but....
+        ret=$?
+## Prior to capturing the results= of the lizardfs-admin metadataserver-status command it is possible to exit(0) while stopping
+## Error: Can't connect to 127.0.0.1:9421: ENOTCONN (Transport endpoint is not connected)  #### exit(0) While Stopping
+## Error: Can't read data from socket: timeout                                             #### exit(1) While Starting during newly downloaded metadata from master server
+        if [ $ret -eq 0 ] ; then
+# Exit was 0, but if an error included ENOTCONN then the shadow service is stoping, return a unique response
+## metadataserver[000]: DEBUG: running in shadow mode, latest metadata is not available: 3 < 1098959141
+## After capturing the results= of the lizardfs-admin metadataserver-status command, this state should never be encountered
+		if [ `grep -c ENOTCONN /tmp/lizardfs_probe` -gt 0 ] ; then
+			echo -e "shadow\tstopping\t3"
+		else
+# Exit was 0, no error so return the normal probe results
+## metadataserver[000]: DEBUG: running in shadow mode, have latest metadata: 1098959141 ## If the cluster is idle and there have been no changes.
+## metadataserver[000]: DEBUG: running in shadow mode, no metadata # If the cluster is active and the metadata version has increased.
+			echo "$results"
+		fi
+# Exit was 1, so we might be stopping or starting and processing newly aquired metadata from the master server.
+	else
+# Error output included ENOTCONN so the shadow service is stoping, return a unique response
+## metadataserver[000]: DEBUG: running in shadow mode, latest metadata is not available: 2 < 1098959141
+		if [ `grep -c ENOTCONN /tmp/lizardfs_probe` -gt 0 ] ; then
+			echo -e "shadow\tstopping\t2"
+# Check for recent file activity and return a unique response if there is file activity in the last minute.
+## metadataserver[000]: DEBUG: running in shadow mode, latest metadata is not available: 1 < 1098959141
+# Verified that is `killall mfsmaster` this "unexpected output from lizardfs-admin:" will at least keep corosync from acting until the shutdown exits cleanly.
+		elif [ ! -z 'find ${data_dir}/ -mmin -1' ] ; then
+			echo -e "shadow\tconnected\t1"
+		fi
+	fi
+# else we returned nothing? shrugs
 }
 
 update_master_score() {
@@ -386,17 +418,8 @@ lizardfs_master_monitor() {
 		# master
 		probe_result=$(lizardfs_probe)
 		if [ $? -ne 0 ] ; then
-# Failed to query via port.
-# But we might still be starting or stopping...
-# Check if we have a lock file before deciding our state
-		if [ -e "$master_lock" ] ; then
-			ocf_log debug "LizardFS metadata server might be starting or stopping."
-			update_master_score ${score_shadow_no_metadata}
-			return $OCF_RUNNING_MASTER
-		else
 			ocf_log err "failed to query LizardFS master status"
 			return $OCF_ERR_GENERIC
-		fi
 		fi
 		local personality=$(echo "$probe_result" | cut -f1)
 		local connection=$(echo "$probe_result" | cut -f2)
@@ -409,7 +432,7 @@ lizardfs_master_monitor() {
 				set_metadata_version "${metadata_version}"
 				return $OCF_RUNNING_MASTER
 			;;
-			shadow/connected|shadow/disconnected)
+			shadow/connected|shadow/disconnected|shadow/stopping)
 				local cluster_metadata_version=$(get_metadata_version)
 				if [[ ( $? != 0 ) || ( ${cluster_metadata_version} == "" ) ]] ; then
 					ocf_log error "Failed to obtain metadata version from cluster."
@@ -558,7 +581,7 @@ case "$1" in
 	reload)   lizardfs_master_reload;;
 	promote)  lizardfs_master_promote;;
 	demote)   lizardfs_master_demote;;
-	#notify)   lizardfs_master_notify;;
+	# notify)   lizardfs_master_notify;;
 	# We have already validated by now
 	validate-all) ;;
 	*)        usage; exit $OCF_ERR_UNIMPLEMENTED;;

--- a/src/ha-cluster/metadataserver.in
+++ b/src/ha-cluster/metadataserver.in
@@ -353,25 +353,12 @@ lizardfs_probe() {
 		host=$matocl_host
 	fi
 # Send any errors to /tmp/lizardfs_probe for later examination
-	results=`lizardfs-admin metadataserver-status --porcelain "${host}" "$matocl_port" 2>|/tmp/lizardfs_probe`
+	probe_results=$(lizardfs-admin metadataserver-status --porcelain "${host}" "$matocl_port" 2>|/tmp/lizardfs_probe)
         ret=$?
-## Prior to capturing the results= of the lizardfs-admin metadataserver-status command it is possible to exit(0) while stopping
-## Error: Can't connect to 127.0.0.1:9421: ENOTCONN (Transport endpoint is not connected)  #### exit(0) While Stopping
-## Error: Can't read data from socket: timeout                                             #### exit(1) While Starting during newly downloaded metadata from master server
         if [ $ret -eq 0 ] ; then
-# Exit was 0, but if an error included ENOTCONN then the shadow service is attempting to stop cleanly, wait for it
-## After capturing the results= of the lizardfs-admin metadataserver-status command, this state should never be encountered
-		if [ `grep -c ENOTCONN /tmp/lizardfs_probe` -gt 0 ] ; then
-			echo -e "shadow\tstopping"
-		else
-# Exit was 0 && no exit error so return the normal probe results
-## metadataserver[000]: DEBUG: running in shadow mode, have latest metadata: 123456789 ## If the cluster is idle and there have been no changes.
-## metadataserver[000]: DEBUG: running in shadow mode, no metadata # If the cluster is active and the metadata version has increased.
-			echo "$results"
-		fi
-# Else, Exit code 1, so we might be stopping or syncing (starting and processing newly acquired metadata from the master server)
+		echo "$probe_results"
 	else
-# Error output included ENOTCONN so the shadow service is stopping, return a unique response
+# Error output included ENOTCONN so the shadow service is stopping, everything is ok, just wait.
 		if [ `grep -c ENOTCONN /tmp/lizardfs_probe` -gt 0 ] ; then
 			echo -e "shadow\tstopping"
 # Check for recent file activity and return a unique response if there is file activity in the last minute.
@@ -382,6 +369,7 @@ lizardfs_probe() {
 # else we returned nothing? shrugs
 # Verified `killall mfsmaster` externally kills mfsmaster that corosync will wait for a clean exit and then start shadow master again.
 # Verified `killall -9 mfsmaster` (Crash) kills mfsmaster than `mfsmetarestore -a ; crm resource cleanup lizardfs-ms` is needed to restore node.
+# If mfsmaster is killed externally then pacemaker may "lose track" of the process? causing pacemaker to not attempt to stop it when pacemaker is stopped.
 }
 
 update_master_score() {

--- a/src/ha-cluster/metadataserver.in
+++ b/src/ha-cluster/metadataserver.in
@@ -616,7 +616,10 @@ lizardfs_master_monitor() {
 				msg="running in master mode"
 				ocf_log debug "$msg" ; test $debug && ocf_log notice "$msg"
 				update_master_score ${score_master}
-				set_metadata_version "${metadata_version}"
+# type_op will be set to something if we are doing any sort of transition,  In a constantly
+# active cluster setting the metadata version here due to a transition will cause a transition
+# abort or delay and we will end up in an ugly loop where by no action will be attempted.
+				[[ -z ${type_op} ]] && set_metadata_version "${metadata_version}"
 				return $OCF_RUNNING_MASTER
 			;;
 			master/stopping)
@@ -629,8 +632,8 @@ lizardfs_master_monitor() {
 			master/busy)
 				msg="running in master mode, but busy"
 				ocf_log debug "$msg" ; test $debug && ocf_log notice "$msg"
-#				update_master_score ${score_master}
-#				set_metadata_version "${metadata_version}"
+#Not if Busy#			update_master_score ${score_master}
+#Not if Busy#			set_metadata_version "${metadata_version}"
 				return $OCF_RUNNING_MASTER
 			;;
 #			master/starting)

--- a/src/ha-cluster/metadataserver.in
+++ b/src/ha-cluster/metadataserver.in
@@ -190,6 +190,7 @@ lizardfs_master_start_shadow() {
 	# slave state, which means starting a shadow master.
 
 	ocf_run lizardfs_master start shadow
+	touch /tmp/lfs-`date +\%Y\%m\%d.\%H\%M\%S`-StartShadow
 }
 
 metadataserver_really_stop() {
@@ -197,6 +198,7 @@ metadataserver_really_stop() {
 		return $OCF_SUCCESS
 	else
 		ocf_log warn "failed to stop LizardFS metadata server, killing instead"
+		touch /tmp/lfs-`date +\%Y\%m\%d.\%H\%M\%S`-Kill
 		if ocf_run lizardfs_master kill ; then
 			return $OCF_SUCCESS
 		else
@@ -211,6 +213,7 @@ lizardfs_master_stop() {
 	case $? in
 		$OCF_RUNNING_MASTER|$OCF_SUCCESS)
 			ocf_log debug "trying to gracefully shutdown LizardFS metadata server"
+			touch /tmp/lfs-`date +\%Y\%m\%d.\%H\%M\%S`-Stop
 			metadataserver_really_stop
 		;;
 		$OCF_NOT_RUNNING)
@@ -245,6 +248,7 @@ lizardfs_master_promote() {
 
 			if [[ "${promote_mode}" == "restart" ]] ; then
 				ocf_log debug "running in shadow mode on cluster with no master, doing full restart"
+				touch /tmp/lfs-`date +\%Y\%m\%d.\%H\%M\%S`-FirstMaster
 				if ! ( ocf_run lizardfs_master stop master && unlink "${master_lock}" && ocf_run lizardfs_master start master ) ; then
 					ocf_log error "Failed to restart into master mode"
 					return $OCF_FAILED_MASTER
@@ -265,6 +269,7 @@ lizardfs_master_promote() {
 			case $ret in
 				$OCF_RUNNING_MASTER)
 					ocf_log info "LizardFS metadata server promoted successfully"
+					touch /tmp/lfs-`date +\%Y\%m\%d.\%H\%M\%S`-Promote
 					return $OCF_SUCCESS
 				;;
 				*)  ocf_log err "LizardFS metadata server failed to promote"
@@ -314,6 +319,8 @@ lizardfs_master_demote() {
 	case $? in
 		$OCF_RUNNING_MASTER)
 			ocf_log debug "LizardFS metadata server running as master, demoting"
+			ocf_run lizardfs_admin_quick_stop && unlink "${master_lock}" # May refuse if there are no shadows present, but that is ok
+			touch /tmp/lfs-`date +\%Y\%m\%d.\%H\%M\%S`-Demote
 		;;
 		$OCF_SUCCESS)
 			ocf_log info "LizardFS metadata server already a shadow master"
@@ -326,7 +333,10 @@ lizardfs_master_demote() {
 		;;
 	esac
 
-	if ! ocf_run lizardfs_master restart shadow ; then
+# Do not bother to start the shadow again, trying to do so just causes the demotion to fail.
+	return $OCF_SUCCESS # so return now.
+# perhaps we could call the lizardfs_master_start_shadow function with more success
+	if ! ocf_run lizardfs_master start shadow ; then # This was originally a restart which does not make sense if we just stopped.
 		ocf_log error "Failed to start shadow master, demotion failed"
 		return $OCF_ERR_GENERIC
 	fi
@@ -359,6 +369,7 @@ lizardfs_probe() {
 		echo "$probe_results"
 	else
 # Error output included ENOTCONN so the shadow service is stopping, everything is ok, just wait.
+# This state could mean that the "shadow is stopping" or that the "master is starting", figure out how to tell them apart.
 		if [ `grep -c ENOTCONN /tmp/lizardfs_probe` -gt 0 ] ; then
 			echo -e "shadow\tstopping"
 # Check for recent file activity and return a unique response if there is file activity in the last minute.
@@ -366,10 +377,13 @@ lizardfs_probe() {
 			echo -e "shadow\tsyncing"
 		fi
 	fi
-# else we returned nothing? shrugs
-# Verified `killall mfsmaster` externally kills mfsmaster that corosync will wait for a clean exit and then start shadow master again.
-# Verified `killall -9 mfsmaster` (Crash) kills mfsmaster than `mfsmetarestore -a ; crm resource cleanup lizardfs-ms` is needed to restore node.
-# If mfsmaster is killed externally then pacemaker may "lose track" of the process? causing pacemaker to not attempt to stop it when pacemaker is stopped.
+# else we returned nothing?
+}
+
+lizardfs_admin_quick_stop() {
+	# Stop metadata server without saving metadata to file
+	echo -n "${admin_password}" | \
+			lizardfs-admin stop-master-without-saving-metadata "${matocl_host}" "$matocl_port"
 }
 
 update_master_score() {
@@ -418,13 +432,13 @@ lizardfs_master_monitor() {
 				return $OCF_RUNNING_MASTER
 			;;
 			shadow/stopping)
-				ocf_log debug "running in shadow mode, service is stopping."
+				ocf_log debug "running in shadow mode and stopping, or running in master mode and starting."
 				# Do not promote shadow if it is shutting down.
 				update_master_score ${score_shadow_no_metadata}
 				return $OCF_SUCCESS
 			;;
 			shadow/syncing)
-				ocf_log debug "running in shadow mode, syncing up with master."
+				ocf_log debug "running in shadow mode, syncing with master."
 				# Do not promote shadow which is syncing up to the master during startup
 				update_master_score ${score_shadow_no_metadata}
 				return $OCF_SUCCESS
@@ -578,7 +592,7 @@ case "$1" in
 	reload)   lizardfs_master_reload;;
 	promote)  lizardfs_master_promote;;
 	demote)   lizardfs_master_demote;;
-	# notify)   lizardfs_master_notify;;
+	notify)   lizardfs_master_notify;;
 	# We have already validated by now
 	validate-all) ;;
 	*)        usage; exit $OCF_ERR_UNIMPLEMENTED;;

--- a/src/ha-cluster/metadataserver.in
+++ b/src/ha-cluster/metadataserver.in
@@ -93,8 +93,12 @@ promote_mode="prevent"
 # sed -i 's%debug: off%debug: on%' /etc/corosync/corosync.conf # To enable normal & noisy debugging.
 # Normally the /tmp folder is ethereal while /var/tmp/ is persistent, using /tmp folder by default.
 # touch /tmp/lfs-debug to enable some useful debugging log messages and touching at state changes.
+# DEBUG_STATE_CHANGE = /var/tmp # in master.cfg and then touch /var/tmp/lfs-debug to survive reboots:
 debug_state_change_logs=$(read_cfg_var ${OCF_RESKEY_master_cfg} DEBUG_STATE_CHANGE = /tmp)
 debug="" ; if [[ -f $debug_state_change_logs/lfs-debug ]] ; then debug=1; fi
+# SHADOW_METADATA_RETENTION = minutes # delete shadows metadata.mfs.DateStamp files after this many minutes
+# 4320=3days, 5760=4, 7200=5, 8640=6, 10080=7 (default), 11520=8 days
+shadow_metadata_retention=$(read_cfg_var ${OCF_RESKEY_master_cfg} SHADOW_METADATA_RETENTION = 10080)
 
 # About
 
@@ -259,10 +263,13 @@ metadataserver_really_stop() {
 			if [[ ${local_metadata_version} -gt 0 ]] ; then
 				msg="Was running in shadow mode with version ${local_metadata_version} so moving the metadata.mfs out of view."
 				ocf_log warn "$msg" ; test $debug && ocf_log notice "$msg" 
+# This is a rather poor way to rotate metadata files. We want to force the rotation of the metadata.mfs when
+# a shadow is stopped so the shadow can not automatically seed the cluster without manual intervention.
 				test -e "${master_metadata}.3" && mv "${master_metadata}.3" "${master_metadata}.`date +\%Y\%m\%d.\%H\%M\%S`"
 				test -e "${master_metadata}.2" && mv "${master_metadata}.2" "${master_metadata}.3"
 				test -e "${master_metadata}.1" && mv "${master_metadata}.1" "${master_metadata}.2"
 				test -e "${master_metadata}"   && mv "${master_metadata}" "${master_metadata}.1"
+				find ${master_metadata}.* -mmin +${shadow_metadata_retention} -ls -delete # If noone notices within 7 days, delete them.
 			else
 				msg="Was running in shadow mode but had no metadata."
 				ocf_log warn "$msg" ; test $debug && ocf_log notice "$msg" 

--- a/src/ha-cluster/metadataserver.in
+++ b/src/ha-cluster/metadataserver.in
@@ -620,7 +620,9 @@ lizardfs_master_monitor() {
 				return $OCF_SUCCESS
 			;;
 			shadow/syncing)
-				msg="running in shadow mode, syncing with master."
+#				rssize=$( ps aux|grep "[m]fsmaster -c"|awk '{print $5}' )
+				rssize=$( ps h -o rss -p `pgrep mfsmaster` 2>/dev/null )
+				msg="running in shadow mode, syncing with master. Local RSS is ${rssize}"
 				ocf_log debug "$msg" ; test $debug && ocf_log notice "$msg"
 				# Do not promote shadow which is syncing up to the master during startup
 				update_master_score ${score_shadow_no_metadata}
@@ -654,7 +656,9 @@ lizardfs_master_monitor() {
 					update_master_score ${score_shadow_connected}
 					promote_mode="reload"
 				else
-					msg="running in shadow mode, no metadata ${local_metadata_version} < ${cluster_metadata_version}."
+					acquired_size=$( stat ${master_metadata}.tmp -c %s 2>/dev/null )
+					previous_size=$( stat ${master_metadata}.1   -c %s 2>/dev/null )
+					msg="running in shadow mode, no metadata ${local_metadata_version} < ${cluster_metadata_version}. Acquiring ${acquired_size}/${previous_size} metadata."
 					ocf_log debug "$msg" ; test $debug && ocf_log notice "$msg"
 					# Do not promote shadow with no metadata!
 					update_master_score ${score_shadow_no_metadata}

--- a/src/ha-cluster/metadataserver.in
+++ b/src/ha-cluster/metadataserver.in
@@ -164,6 +164,45 @@ Config file for LizardFS metadata server; will find in config_dir if not specifi
 EOF
 }
 
+intervention_required() {
+# return $OCF_ERR_PERM # exit and block node from cluster until manual intervention otherwise it keeps trying to get promoted...
+# Demotions of master nodes attempt to use quick-stop which succeeds if there are shadows online.
+# Stops of shaows nodes with valid metadata are followed by the rotation of their metadata files.
+# If a quick stopped master or shadow with rotated metadata attempts to be promoted (which it will)...
+# it is perm(issions/inently) failed from the cluster until someone intervenes.
+ocf_log error "#####"
+ocf_log error "##### This state indicates that either the master process has crashed, or "
+ocf_log error "##### a stopped shadow or demoted master is attempting to seed the cluster."
+case $1 in
+	"promotion to master was prevented by monitor") ocf_log error "#####           $1" ;;
+	"LizardFS metadata server has failed"         ) ocf_log error "#####           $1" ;;
+	*                                             ) ocf_log error "#####           $1" ;;
+esac
+ocf_log error "#####"
+ocf_log error "##### The Corosync LizardFS Cluster may require manual intervention.  At the very"
+ocf_log error "##### least this node will need a little help before it begine to participate"
+ocf_log error "##### again.  Only the last master node in the cluster is allowed to be the first"
+ocf_log error "##### master when the cluster is started again.  Perhaps this error occured"
+ocf_log error "##### because this shadow node came online before the previous master node.  In"
+ocf_log error "##### that case the best course of action is simply to: 1:Wait for the previous"
+ocf_log error "##### master node to come back online.  2:Reboot this node, restart"
+ocf_log error "##### pacemaker/corosync, or do a resource cleanup..."
+ocf_log error "#####"
+ocf_log error "##### 3:If you know the previous master node is unavailable and need to choose"
+ocf_log error "##### from the shadows.  4:You can examine the state of the metadata on each"
+ocf_log error "##### shadow members disk with:"
+ocf_log error "#####  : mfsmetadump ${master_metadata}.1 | head -n 2 | cut -f5-6 -d\  # at each node."
+ocf_log error "##### 5:On the node with the largest value for the metadata version you can run:"
+ocf_log error "#####  : mfsmetarestore -a # to restore usable metadata with which to start."
+ocf_log error "##### 6:Once you are ready to try again with a shadow node run this to try again:"
+ocf_log error "#####  : crm resource cleanup lizardfs-ms # clear all cluster errors and try again."
+ocf_log error "#####"
+ocf_log error "##### If this node crashed try: rm ${master_lock} && crm resource cleanup lizardfs-ms"
+ocf_log error "#####"
+}
+# Consider adding an automated self `crm resource cleanup lizardfs-ms`
+# command once a master does succeed at coming online just after:
+# INFO: LizardFS metadata server promoted successfully
 
 # Utilities
 
@@ -208,7 +247,35 @@ lizardfs_master_start_shadow() {
 
 metadataserver_really_stop() {
 	if ocf_run lizardfs_master stop ; then
-		return $OCF_SUCCESS
+# if we stopped cleanly and were a shadow then move metadata to metadata.mfs.1 so that
+# shadow nodes can not be started again as a cluster master node without intervention.
+		case "$personality" in
+                        master)
+			msg="Was running in master mode so leaving the metadata.mfs as is."
+			ocf_log warn "$msg" ; test $debug && ocf_log notice "$msg" 
+			return $OCF_SUCCESS
+		;;
+                        shadow)
+			if [[ ${local_metadata_version} -gt 0 ]] ; then
+				msg="Was running in shadow mode with version ${local_metadata_version} so moving the metadata.mfs out of view."
+				ocf_log warn "$msg" ; test $debug && ocf_log notice "$msg" 
+				test -e "${master_metadata}.3" && mv "${master_metadata}.3" "${master_metadata}.`date +\%Y\%m\%d.\%H\%M\%S`"
+				test -e "${master_metadata}.2" && mv "${master_metadata}.2" "${master_metadata}.3"
+				test -e "${master_metadata}.1" && mv "${master_metadata}.1" "${master_metadata}.2"
+				test -e "${master_metadata}"   && mv "${master_metadata}" "${master_metadata}.1"
+			else
+				msg="Was running in shadow mode but had no metadata."
+				ocf_log warn "$msg" ; test $debug && ocf_log notice "$msg" 
+			fi
+                        test -e "${master_lock}" && unlink "${master_lock}"
+			return $OCF_SUCCESS
+		;;
+			*)
+			msg="Could not determine which mode we were running in."
+			ocf_log warn "$msg" ; test $debug && ocf_log notice "$msg" 
+			return $OCF_SUCCESS
+		;;
+		esac
 	else
 		msg="failed to stop LizardFS metadata server, killing instead"
 		ocf_log warn "$msg" ; test $debug && ocf_log notice "$msg" 
@@ -229,8 +296,6 @@ lizardfs_master_stop() {
 			msg="trying to gracefully shutdown LizardFS metadata server"
 			ocf_log debug "$msg" ; test $debug && ocf_log notice "$msg"
 	test $debug && touch $debug_state_change_logs/lfs-`date +\%Y\%m\%d.\%H\%M\%S`-Stop
-# First attempt to quick stop then cleanly stop. See ManualIntervention
-			lizardfs_admin_quick_stop && unlink "${master_lock}"
 			metadataserver_really_stop
 		;;
 		$OCF_NOT_RUNNING)
@@ -287,27 +352,13 @@ lizardfs_master_promote() {
 				fi
 			else
 				ocf_log error "promotion to master was prevented by monitor"
-#				return $OCF_SUCCESS
-## ManualIntervention
-# This state occurs when a master was quickly stopped. It can rejoin as a shadow but can not become the first master.
-# If it attempts to do so then perm(issions/inently) fail it from the cluster until the errors are manually cleaned up.
-# All Demotion and Stop actions attempt to use the lizardfs_admin_quick_stop function
-# Quick stop results in an inability to start cleanly as the initial master.
-# Attempting to quick stop if there are no loggers will refuse and do a full clean stop instead.
-# The end result is that only the last metamaster server to be stopped will be able to start.
-# In the event of all nodes failing to become initial master:
-# All running nodes will have current changelog.mfs from which mfsmetarestore -a can be used.
-# Then echo `mfsmetadump /var/lib/mfs/metadata.mfs | head -n 2 | cut -f5-6 -d\ ` # for versions.
-# Finally crm resource cleanup lizardfs-ms # to release the desired member to become initial master.
-# DAMN IT, this is not true when a shadow quick stops it is still able to be the first to start, sigh.....
-## Would need to resort to manually manipulating a stopped shadows metadata files, would like to avoid.
-	ocf_log error "#####"
-	ocf_log error "##### If you would really like this node to become the initial master then you can run these commands:"
-	ocf_log error "##### mfsmetarestore -a ; crm resource cleanup lizardfs-ms # to attempt to cleanup the metadata and clear errors."
-	ocf_log error "##### If you do so you may be reverting to an old metedata set.  Be very sure this is what you want to do."
-	ocf_log error "##### If you just want this node to attempt to rejoin as a shadow then restart or use the cleanup command."
-	ocf_log error "#####"
-	return $OCF_ERR_PERM # exit and block node from cluster
+				intervention_required "promotion to master was prevented by monitor"
+				return $OCF_ERR_PERM # exit and block node from cluster until manual intervention otherwise let it keep trying...
+# If we do not exit and block node now it will just keep trying to promote a shadow with no metadata
+# Would be far better if corosync would not attempt to promote a shadow that has no metadata.
+# Ultimately it would just leave the shadow running and waiting for a master to appear.
+# Having issues the intervention_required message just once in case a reminder is needed
+				return $OCF_SUCCESS
 			fi
 
 			# Check that we are now succesfully a master
@@ -370,7 +421,8 @@ lizardfs_master_demote() {
 	lizardfs_master_monitor
 	case $? in
 		$OCF_RUNNING_MASTER)
-			# Node may refuse to quickly stop if there are no shadows present, but that is ok
+			# Node may refuse to quickly stop if there are no shadows present
+			# Refusal to quick stop with no shadows is manditory, so this is ok.
 			msg="LizardFS metadata server running as master, demoting"
 			ocf_log debug "$msg" ; test $debug && ocf_log notice "$msg"
 	test $debug && touch $debug_state_change_logs/lfs-`date +\%Y\%m\%d.\%H\%M\%S`-Demote
@@ -488,7 +540,7 @@ get_metadata_version_from_file() {
 
 # Check if the mfsmaster process is running on this machine, and if so
 # check if it is as a master or a shadow master.
-# Sets global variable "promote_mode".
+# Sets global variable "promote_mode" and "personality".
 lizardfs_master_monitor() {
 	ocf_run -info lizardfs_master isalive
 	ret=$?
@@ -502,7 +554,7 @@ lizardfs_master_monitor() {
 			ocf_log err "$msg" ; test $debug && ocf_log notice "$msg"
 			return $OCF_ERR_GENERIC
 		fi
-		local personality=$(echo "$probe_result" | cut -f1)
+		personality=$(echo "$probe_result" | cut -f1)
 		local connection=$(echo "$probe_result" | cut -f2)
 		local metadata_version=$(echo "$probe_result" | cut -f3)
 		promote_mode="prevent"
@@ -549,7 +601,7 @@ lizardfs_master_monitor() {
 					return $OCF_ERR_GENERIC
 				fi
 				if [[ ${metadata_version} -gt 0 ]] ; then
-					local local_metadata_version="${metadata_version}"
+					local_metadata_version="${metadata_version}"
 					local in_memory=1
 				else
 					local local_metadata_version=$(get_metadata_version_from_file)
@@ -569,10 +621,15 @@ lizardfs_master_monitor() {
 					update_master_score ${score_shadow_connected}
 					promote_mode="reload"
 				else
-					msg="running in shadow mode, no metadata."
+					msg="running in shadow mode, no metadata ${local_metadata_version}."
 					ocf_log debug "$msg" ; test $debug && ocf_log notice "$msg"
 					# Do not promote shadow with no metadata!
 					update_master_score ${score_shadow_no_metadata}
+#					promote_mode="prevent" # This is already our value...
+# corosync still attempts to promote a shadow with no metadata
+# would be best if it did not even attempt a promotion, but it does.
+# So when the promotion fails we must return $OCF_ERR_PERM # exit and block node from cluster until manual intervention otherwise let it keep trying...
+                                
 				fi
 				return $OCF_SUCCESS
 			;;
@@ -590,10 +647,7 @@ lizardfs_master_monitor() {
 		else
 			msg="LizardFS metadata server has failed"
 			ocf_log warn "$msg" ; test $debug && ocf_log notice "$msg"
-ocf_log error "#####"
-ocf_log error "##### This node may have crashed, Try: rm ${master_lock} && crm resource cleanup lizardfs-ms"
-ocf_log error "#####"
-#unlink "${master_lock}"
+			intervention_required "$msg"
 			return $OCF_FAILED_MASTER
 		fi
 	else
@@ -640,7 +694,7 @@ ensure_dirs() {
 	fi
 	if [ ! -e "$data_dir"/metadata.mfs ] ; then
 		if [ ! -e "$data_dir"/metadata.mfs.back ] ; then
-			if ! echo "MFSM NEW" > "$data_dir"/metadata.mfs ; then
+			if ! echo "MFSM NEW" > "$data_dir"/metadata.mfs.empty ; then
 				return $OCF_ERR_PERM
 			fi
 		fi

--- a/src/ha-cluster/metadataserver.in
+++ b/src/ha-cluster/metadataserver.in
@@ -354,37 +354,39 @@ lizardfs_probe() {
 	fi
 # Send any errors to /tmp/lizardfs_probe for later examination
 	results=`lizardfs-admin metadataserver-status --porcelain "${host}" "$matocl_port" 2>|/tmp/lizardfs_probe`
-# Capture the exit code from this probe command, 0 exited cleanly, but....
         ret=$?
 ## Prior to capturing the results= of the lizardfs-admin metadataserver-status command it is possible to exit(0) while stopping
 ## Error: Can't connect to 127.0.0.1:9421: ENOTCONN (Transport endpoint is not connected)  #### exit(0) While Stopping
 ## Error: Can't read data from socket: timeout                                             #### exit(1) While Starting during newly downloaded metadata from master server
         if [ $ret -eq 0 ] ; then
-# Exit was 0, but if an error included ENOTCONN then the shadow service is stoping, return a unique response
-## metadataserver[000]: DEBUG: running in shadow mode, latest metadata is not available: 3 < 1098959141
+# Exit was 0, but if an error included ENOTCONN then the shadow service is stopping, return a unique response
+## metadataserver[000]: DEBUG: running in shadow mode, latest metadata is not available: 3 < 123456789
 ## After capturing the results= of the lizardfs-admin metadataserver-status command, this state should never be encountered
 		if [ `grep -c ENOTCONN /tmp/lizardfs_probe` -gt 0 ] ; then
 			echo -e "shadow\tstopping\t3"
 		else
-# Exit was 0, no error so return the normal probe results
-## metadataserver[000]: DEBUG: running in shadow mode, have latest metadata: 1098959141 ## If the cluster is idle and there have been no changes.
+# Exit was 0 && no error so return the normal probe results
+## metadataserver[000]: DEBUG: running in shadow mode, have latest metadata: 123456789 ## If the cluster is idle and there have been no changes.
 ## metadataserver[000]: DEBUG: running in shadow mode, no metadata # If the cluster is active and the metadata version has increased.
 			echo "$results"
 		fi
-# Exit was 1, so we might be stopping or starting and processing newly aquired metadata from the master server.
+# Else, Exit was 1, so we might be stopping or starting and processing newly acquired metadata from the master server.
 	else
-# Error output included ENOTCONN so the shadow service is stoping, return a unique response
-## metadataserver[000]: DEBUG: running in shadow mode, latest metadata is not available: 2 < 1098959141
+# Error output included ENOTCONN so the shadow service is stopping, return a unique response
+## metadataserver[000]: DEBUG: running in shadow mode, latest metadata is not available: 2 < 123456789
 		if [ `grep -c ENOTCONN /tmp/lizardfs_probe` -gt 0 ] ; then
 			echo -e "shadow\tstopping\t2"
 # Check for recent file activity and return a unique response if there is file activity in the last minute.
-## metadataserver[000]: DEBUG: running in shadow mode, latest metadata is not available: 1 < 1098959141
-# Verified that is `killall mfsmaster` this "unexpected output from lizardfs-admin:" will at least keep corosync from acting until the shutdown exits cleanly.
+## metadataserver[000]: DEBUG: running in shadow mode, latest metadata is not available: 1 < 123456789
 		elif [ ! -z 'find ${data_dir}/ -mmin -1' ] ; then
-			echo -e "shadow\tconnected\t1"
+			echo -e "shadow\tsyncing\t1"
 		fi
 	fi
 # else we returned nothing? shrugs
+# Verified `killall mfsmaster` externally kills mfsmaster that corosync will now wait for a clean exit and then start shadow master again.
+# Verified `killall -9 mfsmaster` (Crash) kills mfsmaster than `mfsmetarestore -a ; crm resource cleanup lizardfs-ms` is needed to restore node.
+##### Would be better to handle "shadow\tstopping\t0" and "shadow\tsyncing\t0" with unique DEBUG: output indicating we are stopping or syncing
+##### Until then I like to see "1 < 123456789" indicating we are syncing and "2 < 123456789" indicating we are stopping...
 }
 
 update_master_score() {
@@ -432,7 +434,19 @@ lizardfs_master_monitor() {
 				set_metadata_version "${metadata_version}"
 				return $OCF_RUNNING_MASTER
 			;;
-			shadow/connected|shadow/disconnected|shadow/stopping)
+			shadow/stopping)
+				ocf_log debug "running in shadow mode, service is stopping."
+				# Do not promote shadow if it is shutting down.
+				update_master_score ${score_shadow_no_metadata}
+				return $OCF_SUCCESS
+			;;
+			shadow/syncing)
+				ocf_log debug "running in shadow mode, syncing up with master."
+				# Do not promote shadow which is syncing up to the master during startup
+				update_master_score ${score_shadow_no_metadata}
+				return $OCF_SUCCESS
+			;;
+			shadow/connected|shadow/disconnected)
 				local cluster_metadata_version=$(get_metadata_version)
 				if [[ ( $? != 0 ) || ( ${cluster_metadata_version} == "" ) ]] ; then
 					ocf_log error "Failed to obtain metadata version from cluster."

--- a/src/ha-cluster/metadataserver.in
+++ b/src/ha-cluster/metadataserver.in
@@ -575,7 +575,9 @@ update_master_score() {
 }
 
 set_metadata_version() {
-	msg="LizardFS: setting cluster metadata version: ${1}"
+	local cluster_metadata_version=$(get_metadata_version)
+        metadata_change=$( expr ${metadata_version} - ${cluster_metadata_version} )
+        msg="LizardFS: setting cluster metadata version: ${1} (${metadata_change})"
 	ocf_log debug "$msg" ; test $debug && ocf_log notice "$msg"
 	ocf_run ${HA_SBIN_DIR}/crm_attribute --lifetime=forever --type=crm_config --name=${metadata_version_attribute_name} --update="${1}"
 }

--- a/src/ha-cluster/metadataserver.in
+++ b/src/ha-cluster/metadataserver.in
@@ -146,19 +146,17 @@ Config file for LizardFS metadata server; will find in config_dir if not specifi
       <content type="string" default="$OCF_RESKEY_master_cfg_default"/>
     </parameter>
   </parameters>
-  <actions>
-    <action name="start"        timeout="45" />
-    <action name="stop"         timeout="45" />
-    <action name="monitor"      timeout="20"
-                                depth="0" interval="20" role="Slave" />
-    <action name="monitor"      timeout="20"
-                                depth="0" interval="10" role="Master" />
+  <actions> 
+    <action name="start"        timeout="1800" />
+    <action name="stop"         timeout="1800" />
+    <action name="monitor"      interval="2" role="Slave"  timeout="40" />
+    <action name="monitor"      interval="1" role="Master" timeout="30" />
     <action name="reload"       timeout="20" />
-    <action name="promote"      timeout="45" />
-    <action name="demote"       timeout="45" />
+    <action name="promote"      timeout="1800" />
+    <action name="demote"       timeout="1800" />
     <!--action name="notify"       timeout="20" /-->
-    <action name="meta-data"    timeout="5" />
-    <action name="validate-all" timeout="5" />
+    <!--<action name="meta-data"    timeout="5" />-->
+    <!--<action name="validate-all" timeout="5" />-->
   </actions>
 </resource-agent>
 EOF

--- a/src/ha-cluster/metadataserver.in
+++ b/src/ha-cluster/metadataserver.in
@@ -239,10 +239,10 @@ lizardfs_master_start_shadow() {
 	# When the start action is called, we are supposed to start in the
 	# slave state, which means starting a shadow master.
 
-	ocf_run lizardfs_master start shadow
 	msg="starting LizardFS metadata server as shadow master"
 	ocf_log info "$msg" ; test $debug && ocf_log notice "$msg"
 	test $debug && touch $debug_state_change_logs/lfs-`date +\%Y\%m\%d.\%H\%M\%S`-StartS
+	ocf_run lizardfs_master start shadow
 }
 
 metadataserver_really_stop() {
@@ -438,6 +438,7 @@ lizardfs_master_demote() {
 			ocf_log debug "$msg" ; test $debug && ocf_log notice "$msg"
 	test $debug && touch $debug_state_change_logs/lfs-`date +\%Y\%m\%d.\%H\%M\%S`-Demote
 			ocf_run lizardfs_admin_quick_stop && unlink "${master_lock}"
+## TODO look into if the exit code from the quick stop is important, in which case the unlink exit code may be getting in the way
 		;;
 		$OCF_SUCCESS)
 			msg="LizardFS metadata server already a shadow master"
@@ -522,11 +523,11 @@ lizardfs_probe() {
 
 lizardfs_admin_quick_stop() {
 	# Stop metadata server without saving metadata to file
-	echo -n "${admin_password}" | \
-		lizardfs-admin stop-master-without-saving-metadata "${matocl_host}" "$matocl_port"
 	msg="LizardFS metadata server quickly stopping."
 	ocf_log debug "$msg" ; test $debug && ocf_log notice "$msg"
 	test $debug && touch $debug_state_change_logs/lfs-`date +\%Y\%m\%d.\%H\%M\%S`-QStop
+	echo -n "${admin_password}" | \
+		lizardfs-admin stop-master-without-saving-metadata "${matocl_host}" "$matocl_port"
 }
 
 update_master_score() {

--- a/src/ha-cluster/metadataserver.in
+++ b/src/ha-cluster/metadataserver.in
@@ -519,6 +519,12 @@ lizardfs_probe() {
 			msg="read data from socket: timeout. Trying to probe again"
 			ocf_log error "$msg" ; test $debug && ocf_log notice "$msg"
 			retry_probe=1 ; sleep 3 ; lizardfs_probe
+## Might also get Can't read data from socket: Connection reset by peer
+		elif [[ "$probe_results" =~ "read data from socket: Connection reset by peer" ]]\
+		 && [[ ! -z `pgrep -f "ha-cluster-managed"` ]] && [[ -z $retry_probe ]] ; then
+			msg="read data from socket: Connection reset by peer. Trying to probe again"
+			ocf_log error "$msg" ; test $debug && ocf_log notice "$msg"
+			retry_probe=1 ; sleep 3 ; lizardfs_probe
 ## probes times out in ~5~7 sec * 3 = 15~21 sec + sleep, corosync default timeout is 20 seconds.
 ## Trying a third probe attempt might exceed the monitor operation timeout, which could be increased...
 #		elif [[ "$probe_results" =~ "read data from socket: timeout" ]]\
@@ -528,6 +534,10 @@ lizardfs_probe() {
 #			retry_probe_again=1 ; lizardfs_probe
 ## After retrying the probe, presume that perhaps the shadow is syncing...
 		elif [[ "$probe_results" =~ "read data from socket: timeout" ]]\
+		 && [[ ! -z `pgrep -f "initial-personality=shadow start"` ]] ; then
+			echo -e "shadow\tsyncing"
+## Might also get Can't read data from socket: Connection reset by peer
+		elif [[ "$probe_results" =~ "read data from socket: Connection reset by peer" ]]\
 		 && [[ ! -z `pgrep -f "initial-personality=shadow start"` ]] ; then
 			echo -e "shadow\tsyncing"
 #		elif [[ "$probe_results" =~ "connection failed, error: ECONNREFUSED (Connection refused)" ]]\

--- a/src/ha-cluster/metadataserver.in
+++ b/src/ha-cluster/metadataserver.in
@@ -82,7 +82,8 @@ matocl_host=$(read_cfg_var ${OCF_RESKEY_master_cfg} MATOCL_LISTEN_HOST = '*')
 matocl_port=$(read_cfg_var ${OCF_RESKEY_master_cfg} MATOCL_LISTEN_PORT = 9421)
 lizardfs_user=$(read_cfg_var ${OCF_RESKEY_master_cfg} WORKING_USER = mfs)
 lizardfs_group=$(read_cfg_var ${OCF_RESKEY_master_cfg} WORKING_GROUP = mfs)
-exports_cfg=/etc/mfs/mfsexports.cfg
+exports_cfg=$(read_cfg_var ${OCF_RESKEY_master_cfg} EXPORTS_FILENAME = /etc/mfs/mfsexports.cfg)
+debug_state_change_cfg=$(read_cfg_var ${OCF_RESKEY_master_cfg} DEBUG_STATE_CHANGE = /tmp)
 
 master_metadata=${data_dir}/metadata.mfs
 master_lock=${data_dir}/metadata.mfs.lock
@@ -164,6 +165,7 @@ lizardfs_master() {
 	local command=$1
 	local personality=$2
 	mfsmaster -c "$OCF_RESKEY_master_cfg" -o ha-cluster-managed -o initial-personality="${personality}" "${command}"
+#	touch $debug_state_change_cfg/lfs-`date +\%Y\%m\%d.\%H\%M\%S`-M_${personality}_${command}
 }
 
 # Actions
@@ -190,7 +192,7 @@ lizardfs_master_start_shadow() {
 	# slave state, which means starting a shadow master.
 
 	ocf_run lizardfs_master start shadow
-	touch /tmp/lfs-`date +\%Y\%m\%d.\%H\%M\%S`-StartShadow
+	touch $debug_state_change_cfg/lfs-`date +\%Y\%m\%d.\%H\%M\%S`-StartS
 }
 
 metadataserver_really_stop() {
@@ -198,7 +200,7 @@ metadataserver_really_stop() {
 		return $OCF_SUCCESS
 	else
 		ocf_log warn "failed to stop LizardFS metadata server, killing instead"
-		touch /tmp/lfs-`date +\%Y\%m\%d.\%H\%M\%S`-Kill
+		touch $debug_state_change_cfg/lfs-`date +\%Y\%m\%d.\%H\%M\%S`-Kill
 		if ocf_run lizardfs_master kill ; then
 			return $OCF_SUCCESS
 		else
@@ -213,7 +215,7 @@ lizardfs_master_stop() {
 	case $? in
 		$OCF_RUNNING_MASTER|$OCF_SUCCESS)
 			ocf_log debug "trying to gracefully shutdown LizardFS metadata server"
-			touch /tmp/lfs-`date +\%Y\%m\%d.\%H\%M\%S`-Stop
+			touch $debug_state_change_cfg/lfs-`date +\%Y\%m\%d.\%H\%M\%S`-Stop
 			metadataserver_really_stop
 		;;
 		$OCF_NOT_RUNNING)
@@ -248,7 +250,7 @@ lizardfs_master_promote() {
 
 			if [[ "${promote_mode}" == "restart" ]] ; then
 				ocf_log debug "running in shadow mode on cluster with no master, doing full restart"
-				touch /tmp/lfs-`date +\%Y\%m\%d.\%H\%M\%S`-FirstMaster
+				touch $debug_state_change_cfg/lfs-`date +\%Y\%m\%d.\%H\%M\%S`-Master1
 				if ! ( ocf_run lizardfs_master stop master && unlink "${master_lock}" && ocf_run lizardfs_master start master ) ; then
 					ocf_log error "Failed to restart into master mode"
 					return $OCF_FAILED_MASTER
@@ -269,7 +271,7 @@ lizardfs_master_promote() {
 			case $ret in
 				$OCF_RUNNING_MASTER)
 					ocf_log info "LizardFS metadata server promoted successfully"
-					touch /tmp/lfs-`date +\%Y\%m\%d.\%H\%M\%S`-Promote
+					touch $debug_state_change_cfg/lfs-`date +\%Y\%m\%d.\%H\%M\%S`-Promote
 					return $OCF_SUCCESS
 				;;
 				*)  ocf_log err "LizardFS metadata server failed to promote"
@@ -320,7 +322,7 @@ lizardfs_master_demote() {
 		$OCF_RUNNING_MASTER)
 			ocf_log debug "LizardFS metadata server running as master, demoting"
 			ocf_run lizardfs_admin_quick_stop && unlink "${master_lock}" # May refuse if there are no shadows present, but that is ok
-			touch /tmp/lfs-`date +\%Y\%m\%d.\%H\%M\%S`-Demote
+			touch $debug_state_change_cfg/lfs-`date +\%Y\%m\%d.\%H\%M\%S`-Demote
 		;;
 		$OCF_SUCCESS)
 			ocf_log info "LizardFS metadata server already a shadow master"
@@ -335,7 +337,7 @@ lizardfs_master_demote() {
 
 # Do not bother to start the shadow again, trying to do so just causes the demotion to fail.
 	return $OCF_SUCCESS # so return now.
-# perhaps we could call the lizardfs_master_start_shadow function with more success
+# Perhaps we could call the lizardfs_master_start_shadow function with more success
 	if ! ocf_run lizardfs_master start shadow ; then # This was originally a restart which does not make sense if we just stopped.
 		ocf_log error "Failed to start shadow master, demotion failed"
 		return $OCF_ERR_GENERIC
@@ -362,28 +364,38 @@ lizardfs_probe() {
 	else
 		host=$matocl_host
 	fi
-# Send any errors to /tmp/lizardfs_probe for later examination
-	probe_results=$(lizardfs-admin metadataserver-status --porcelain "${host}" "$matocl_port" 2>|/tmp/lizardfs_probe)
+# Error: Can't connect to 127.0.0.1:9421: ENOTCONN (Transport endpoint is not connected) ##### While stopping shadow master, stopping initial master, or starting initial master
+# Error: Can't read data from socket: timeout ##### While starting shadow master and reintegrating new metadata received from master
+# Send errors to stdin so we can use them to determin status of service which is not directly responding to the network probes
+	probe_results=$(lizardfs-admin metadataserver-status --porcelain "${host}" "$matocl_port" 2>&1)
         ret=$?
-        if [ $ret -eq 0 ] ; then
+        if [ $ret -eq 0 ] ; then # exited clean, just return the results
 		echo "$probe_results"
-	else
-# Error output included ENOTCONN so the shadow service is stopping, everything is ok, just wait.
-# This state could mean that the "shadow is stopping" or that the "master is starting", figure out how to tell them apart.
-		if [ `grep -c ENOTCONN /tmp/lizardfs_probe` -gt 0 ] ; then
+	else # existed with an error, make some assumptions
+		if   [[ "$probe_results" =~ "ENOTCONN" ]] && [[ ! -z `pgrep -f "initial-personality=shadow start"` ]] ; then
 			echo -e "shadow\tstopping"
-# Check for recent file activity and return a unique response if there is file activity in the last minute.
-		elif [ ! -z 'find ${data_dir}/ -mmin -1' ] ; then
+# Can not rely on checking for recent file activity.
+#		elif [ ! -z `find ${data_dir}/ -mmin -1`    ] ; then # Watch for any 1 minute or newer files
+#		elif [ ! -z `find ${data_dir}/ -mmin -0.02` ] ; then # Watch for any ~1second or newer files
+		elif [[ "$probe_results" =~ "ENOTCONN" ]] && [[ ! -z `pgrep -f "initial-personality=master start"` ]] ; then
+			echo -e "master\tstopping"
+# Can not determin the difference between stopping and starting master service.
+#			echo -e "master\tstarting"
+		elif [[ "$probe_results" =~ "read data from socket: timeout" ]] && [[ ! -z `pgrep -f "initial-personality=shadow start"` ]] ; then
 			echo -e "shadow\tsyncing"
+#		elif [[ ! -z `pgrep -f "initial-personality=shadow start"` ]] ; then
+#			echo -e "shadow\tsyncing"
+		else
+			echo -e "shadow\tunknown"
 		fi
 	fi
-# else we returned nothing?
 }
 
 lizardfs_admin_quick_stop() {
 	# Stop metadata server without saving metadata to file
 	echo -n "${admin_password}" | \
-			lizardfs-admin stop-master-without-saving-metadata "${matocl_host}" "$matocl_port"
+		lizardfs-admin stop-master-without-saving-metadata "${matocl_host}" "$matocl_port"
+	touch $debug_state_change_cfg/lfs-`date +\%Y\%m\%d.\%H\%M\%S`-QStop
 }
 
 update_master_score() {
@@ -431,8 +443,18 @@ lizardfs_master_monitor() {
 				set_metadata_version "${metadata_version}"
 				return $OCF_RUNNING_MASTER
 			;;
+			master/stopping)
+				ocf_log debug "running in master mode and stopping or starting."
+				update_master_score ${score_shadow_no_metadata}
+				return $OCF_SUCCESS
+			;;
+#			master/starting)
+#				ocf_log debug "running in master mode starting up."
+#				update_master_score ${score_shadow_no_metadata}
+#				return $OCF_SUCCESS
+#			;;
 			shadow/stopping)
-				ocf_log debug "running in shadow mode and stopping, or running in master mode and starting."
+				ocf_log debug "running in shadow mode and stopping."
 				# Do not promote shadow if it is shutting down.
 				update_master_score ${score_shadow_no_metadata}
 				return $OCF_SUCCESS
@@ -503,6 +525,7 @@ lizardfs_master_reload() {
 		$OCF_RUNNING_MASTER|$OCF_SUCCESS)
 			ocf_log debug "reloading LizardFS metadata server configuration"
 			if ocf_run lizardfs_master reload ; then
+				touch $debug_state_change_cfg/lfs-`date +\%Y\%m\%d.\%H\%M\%S`-Reload
 				return $OCF_SUCCESS
 			else
 				return $OCF_ERR_GENERIC

--- a/src/ha-cluster/metadataserver.in
+++ b/src/ha-cluster/metadataserver.in
@@ -359,34 +359,29 @@ lizardfs_probe() {
 ## Error: Can't connect to 127.0.0.1:9421: ENOTCONN (Transport endpoint is not connected)  #### exit(0) While Stopping
 ## Error: Can't read data from socket: timeout                                             #### exit(1) While Starting during newly downloaded metadata from master server
         if [ $ret -eq 0 ] ; then
-# Exit was 0, but if an error included ENOTCONN then the shadow service is stopping, return a unique response
-## metadataserver[000]: DEBUG: running in shadow mode, latest metadata is not available: 3 < 123456789
+# Exit was 0, but if an error included ENOTCONN then the shadow service is attempting to stop cleanly, wait for it
 ## After capturing the results= of the lizardfs-admin metadataserver-status command, this state should never be encountered
 		if [ `grep -c ENOTCONN /tmp/lizardfs_probe` -gt 0 ] ; then
-			echo -e "shadow\tstopping\t3"
+			echo -e "shadow\tstopping"
 		else
-# Exit was 0 && no error so return the normal probe results
+# Exit was 0 && no exit error so return the normal probe results
 ## metadataserver[000]: DEBUG: running in shadow mode, have latest metadata: 123456789 ## If the cluster is idle and there have been no changes.
 ## metadataserver[000]: DEBUG: running in shadow mode, no metadata # If the cluster is active and the metadata version has increased.
 			echo "$results"
 		fi
-# Else, Exit was 1, so we might be stopping or starting and processing newly acquired metadata from the master server.
+# Else, Exit code 1, so we might be stopping or syncing (starting and processing newly acquired metadata from the master server)
 	else
 # Error output included ENOTCONN so the shadow service is stopping, return a unique response
-## metadataserver[000]: DEBUG: running in shadow mode, latest metadata is not available: 2 < 123456789
 		if [ `grep -c ENOTCONN /tmp/lizardfs_probe` -gt 0 ] ; then
-			echo -e "shadow\tstopping\t2"
+			echo -e "shadow\tstopping"
 # Check for recent file activity and return a unique response if there is file activity in the last minute.
-## metadataserver[000]: DEBUG: running in shadow mode, latest metadata is not available: 1 < 123456789
 		elif [ ! -z 'find ${data_dir}/ -mmin -1' ] ; then
-			echo -e "shadow\tsyncing\t1"
+			echo -e "shadow\tsyncing"
 		fi
 	fi
 # else we returned nothing? shrugs
-# Verified `killall mfsmaster` externally kills mfsmaster that corosync will now wait for a clean exit and then start shadow master again.
+# Verified `killall mfsmaster` externally kills mfsmaster that corosync will wait for a clean exit and then start shadow master again.
 # Verified `killall -9 mfsmaster` (Crash) kills mfsmaster than `mfsmetarestore -a ; crm resource cleanup lizardfs-ms` is needed to restore node.
-##### Would be better to handle "shadow\tstopping\t0" and "shadow\tsyncing\t0" with unique DEBUG: output indicating we are stopping or syncing
-##### Until then I like to see "1 < 123456789" indicating we are syncing and "2 < 123456789" indicating we are stopping...
 }
 
 update_master_score() {

--- a/src/ha-cluster/metadataserver.in
+++ b/src/ha-cluster/metadataserver.in
@@ -83,12 +83,18 @@ matocl_port=$(read_cfg_var ${OCF_RESKEY_master_cfg} MATOCL_LISTEN_PORT = 9421)
 lizardfs_user=$(read_cfg_var ${OCF_RESKEY_master_cfg} WORKING_USER = mfs)
 lizardfs_group=$(read_cfg_var ${OCF_RESKEY_master_cfg} WORKING_GROUP = mfs)
 exports_cfg=$(read_cfg_var ${OCF_RESKEY_master_cfg} EXPORTS_FILENAME = /etc/mfs/mfsexports.cfg)
-debug_state_change_cfg=$(read_cfg_var ${OCF_RESKEY_master_cfg} DEBUG_STATE_CHANGE = /tmp)
 
 master_metadata=${data_dir}/metadata.mfs
 master_lock=${data_dir}/metadata.mfs.lock
 master_backup_logs=${data_dir}/changelog.mfs.*
 promote_mode="prevent"
+
+# Debugging variables:  These may aid in attempting to debug what corosync and pacemaker are doing.
+# sed -i 's%debug: off%debug: on%' /etc/corosync/corosync.conf # To enable normal & noisy debugging.
+# Normally the /tmp folder is ethereal while /var/tmp/ is persistent, using /tmp folder by default.
+# touch /tmp/lfs-debug to enable some useful debugging log messages and touching at state changes.
+debug_state_change_logs=$(read_cfg_var ${OCF_RESKEY_master_cfg} DEBUG_STATE_CHANGE = /tmp)
+debug="" ; if [[ -f $debug_state_change_logs/lfs-debug ]] ; then debug=1; fi
 
 # About
 
@@ -165,7 +171,7 @@ lizardfs_master() {
 	local command=$1
 	local personality=$2
 	mfsmaster -c "$OCF_RESKEY_master_cfg" -o ha-cluster-managed -o initial-personality="${personality}" "${command}"
-#	touch $debug_state_change_cfg/lfs-`date +\%Y\%m\%d.\%H\%M\%S`-M_${personality}_${command}
+#	test $debug && touch $debug_state_change_logs/lfs-`date +\%Y\%m\%d.\%H\%M\%S`-M_${personality}_${command}
 }
 
 # Actions
@@ -174,14 +180,17 @@ lizardfs_master_start_shadow() {
 	lizardfs_master_monitor
 	case $? in
 		$OCF_RUNNING_MASTER)
-			ocf_log warn "LizardFS metadata server already running in master mode"
+			msg="LizardFS metadata server already running in master mode"
+			ocf_log warn "$msg" ; test $debug && ocf_log notice "$msg"
 			return $OCF_RUNNING_MASTER
 		;;
 		$OCF_SUCCESS)
-			ocf_log info "LizardFS metadata server already running as a shadow master"
+			msg="LizardFS metadata server already running as a shadow master"
+			ocf_log info "$msg" ; test $debug && ocf_log notice "$msg"
 			return $OCF_SUCCESS
 		;;
-		*)  ocf_log debug "starting LizardFS metadata server as shadow master"
+		*)	msg="starting LizardFS metadata server as shadow master"
+			ocf_log debug "$msg" ; test $debug && ocf_log notice "$msg"
 	esac
 
 	if ! ensure_dirs ; then
@@ -192,15 +201,18 @@ lizardfs_master_start_shadow() {
 	# slave state, which means starting a shadow master.
 
 	ocf_run lizardfs_master start shadow
-	touch $debug_state_change_cfg/lfs-`date +\%Y\%m\%d.\%H\%M\%S`-StartS
+	msg="starting LizardFS metadata server as shadow master"
+	ocf_log info "$msg" ; test $debug && ocf_log notice "$msg"
+	test $debug && touch $debug_state_change_logs/lfs-`date +\%Y\%m\%d.\%H\%M\%S`-StartS
 }
 
 metadataserver_really_stop() {
 	if ocf_run lizardfs_master stop ; then
 		return $OCF_SUCCESS
 	else
-		ocf_log warn "failed to stop LizardFS metadata server, killing instead"
-		touch $debug_state_change_cfg/lfs-`date +\%Y\%m\%d.\%H\%M\%S`-Kill
+		msg="failed to stop LizardFS metadata server, killing instead"
+		ocf_log warn "$msg" ; test $debug && ocf_log notice "$msg" 
+	test $debug && touch $debug_state_change_logs/lfs-`date +\%Y\%m\%d.\%H\%M\%S`-Kill
 		if ocf_run lizardfs_master kill ; then
 			return $OCF_SUCCESS
 		else
@@ -214,19 +226,25 @@ lizardfs_master_stop() {
 	lizardfs_master_monitor
 	case $? in
 		$OCF_RUNNING_MASTER|$OCF_SUCCESS)
-			ocf_log debug "trying to gracefully shutdown LizardFS metadata server"
-			touch $debug_state_change_cfg/lfs-`date +\%Y\%m\%d.\%H\%M\%S`-Stop
+			msg="trying to gracefully shutdown LizardFS metadata server"
+			ocf_log debug "$msg" ; test $debug && ocf_log notice "$msg"
+	test $debug && touch $debug_state_change_logs/lfs-`date +\%Y\%m\%d.\%H\%M\%S`-Stop
+# First attempt to quick stop then cleanly stop. See ManualIntervention
+			lizardfs_admin_quick_stop && unlink "${master_lock}"
 			metadataserver_really_stop
 		;;
 		$OCF_NOT_RUNNING)
-			ocf_log info "tried to stop already stopped instance"
+			msg="tried to stop already stopped instance"
+			ocf_log info "$msg" ; test $debug && ocf_log notice "$msg"
 			return $OCF_SUCCESS
 		;;
 		$OCF_FAILED_MASTER)
-			ocf_log info "tried to stop failed master"
+			msg="tried to stop failed master"
+			ocf_log info "$msg" ; test $debug && ocf_log notice "$msg"
 			return $OCF_SUCCESS
 		;;
-		*)  ocf_log error "unknown state ${?}, trying to stop"
+		*)	msg="unknown state ${?}, trying to stop"
+			ocf_log error "$msg" ; test $debug && ocf_log notice "$msg"
 			metadataserver_really_stop
 		;;
 	esac
@@ -236,40 +254,60 @@ lizardfs_master_promote() {
 	lizardfs_master_monitor
 	case $? in
 		$OCF_RUNNING_MASTER)
-			ocf_log info "LizardFS metadata server already running as master"
+			msg="LizardFS metadata server already running as master"
+			ocf_log info "$msg" ; test $debug && ocf_log notice "$msg"
 			return $OCF_SUCCESS
 		;;
 		$OCF_SUCCESS)
-			ocf_log debug "LizardFS metadata server is shadow master, promoting to master"
+			msg="LizardFS metadata server is shadow master, promoting to master"
+			ocf_log debug "$msg" ; test $debug && ocf_log notice "$msg"
 
 			local cluster_metadata_version=$(get_metadata_version)
 			if [[ ( $? != 0 ) || ( ${cluster_metadata_version} == "" ) ]] ; then
-				ocf_log error "Failed to obtain metadata version from cluster."
+				msg="Failed to obtain metadata version from cluster."
+				ocf_log error "$msg" ; test $debug && ocf_log notice "$msg"
 				return $OCF_ERR_GENERIC
 			fi
 
 			if [[ "${promote_mode}" == "restart" ]] ; then
-				ocf_log debug "running in shadow mode on cluster with no master, doing full restart"
-				touch $debug_state_change_cfg/lfs-`date +\%Y\%m\%d.\%H\%M\%S`-Master1
-				if ! ( ocf_run lizardfs_master stop master && unlink "${master_lock}" && ocf_run lizardfs_master start master ) ; then
-					ocf_log error "Failed to restart into master mode"
+				msg="running in shadow mode on cluster with no master, doing full restart"
+				ocf_log debug "$msg" ; test $debug && ocf_log notice "$msg"
+	test $debug && touch $debug_state_change_logs/lfs-`date +\%Y\%m\%d.\%H\%M\%S`-Master1
+				if ! ( ocf_run lizardfs_master stop master && unlink "${master_lock}"\
+				 && ocf_run lizardfs_master start master ) ; then
+					msg="Failed to restart into master mode"
+					ocf_log error "$msg" ; test $debug && ocf_log notice "$msg"
 					return $OCF_FAILED_MASTER
 				fi
 			elif [[ "${promote_mode}" == "reload" ]] ; then
 				if ! ocf_run lizardfs_admin_promote ; then
-					ocf_log error "failed to reload master"
+					msg="failed to reload master"
+					ocf_log error "$msg" ; test $debug && ocf_log notice "$msg"
 					return $OCF_FAILED_MASTER
 				fi
 			else
 				ocf_log error "promotion to master was prevented by monitor"
-				ocf_log error "#####"
-				ocf_log error "##### If you would really like this node to become the initial master then you can run these commands:"
-				ocf_log error "##### mfsmetarestore -a ; crm resource cleanup lizardfs-ms # to attempt to cleanup the metadata and clear errors."
-				ocf_log error "##### If you do so you may be reverting to an old metedata set.  Be very sure this is what you want to do."
-				ocf_log error "##### If you just want this node to attempt to rejoin as a shadow then restart or use the cleanup command."
-				ocf_log error "#####"
-				return $OCF_ERR_PERM
 #				return $OCF_SUCCESS
+## ManualIntervention
+# This state occurs when a master was quickly stopped. It can rejoin as a shadow but can not become the first master.
+# If it attempts to do so then perm(issions/inently) fail it from the cluster until the errors are manually cleaned up.
+# All Demotion and Stop actions attempt to use the lizardfs_admin_quick_stop function
+# Quick stop results in an inability to start cleanly as the initial master.
+# Attempting to quick stop if there are no loggers will refuse and do a full clean stop instead.
+# The end result is that only the last metamaster server to be stopped will be able to start.
+# In the event of all nodes failing to become initial master:
+# All running nodes will have current changelog.mfs from which mfsmetarestore -a can be used.
+# Then echo `mfsmetadump /var/lib/mfs/metadata.mfs | head -n 2 | cut -f5-6 -d\ ` # for versions.
+# Finally crm resource cleanup lizardfs-ms # to release the desired member to become initial master.
+# DAMN IT, this is not true when a shadow quick stops it is still able to be the first to start, sigh.....
+## Would need to resort to manually manipulating a stopped shadows metadata files, would like to avoid.
+	ocf_log error "#####"
+	ocf_log error "##### If you would really like this node to become the initial master then you can run these commands:"
+	ocf_log error "##### mfsmetarestore -a ; crm resource cleanup lizardfs-ms # to attempt to cleanup the metadata and clear errors."
+	ocf_log error "##### If you do so you may be reverting to an old metedata set.  Be very sure this is what you want to do."
+	ocf_log error "##### If you just want this node to attempt to rejoin as a shadow then restart or use the cleanup command."
+	ocf_log error "#####"
+	return $OCF_ERR_PERM # exit and block node from cluster
 			fi
 
 			# Check that we are now succesfully a master
@@ -277,18 +315,20 @@ lizardfs_master_promote() {
 			ret=$?
 			case $ret in
 				$OCF_RUNNING_MASTER)
-					ocf_log info "LizardFS metadata server promoted successfully"
-					touch $debug_state_change_cfg/lfs-`date +\%Y\%m\%d.\%H\%M\%S`-Promote
+					msg="LizardFS metadata server promoted successfully"
+					ocf_log info "$msg" ; test $debug && ocf_log notice "$msg"
+	test $debug && touch $debug_state_change_logs/lfs-`date +\%Y\%m\%d.\%H\%M\%S`-Promote
 					return $OCF_SUCCESS
 				;;
-				*)  ocf_log err "LizardFS metadata server failed to promote"
+				*)	msg="LizardFS metadata server failed to promote"
+					ocf_log err "$msg" ; test $debug && ocf_log notice "$msg"
 					return $OCF_FAILED_MASTER
 				;;
 			esac
 		;;
 		*)
-			ocf_log error \
-				"LizardFS metadata server not running as shadow master, can't be promoted"
+			msg="LizardFS metadata server not running as shadow master, can't be promoted"
+			ocf_log error "$msg" ; test $debug && ocf_log notice "$msg"
 			return $OCF_ERR_GENERIC
 		;;
 	esac
@@ -301,23 +341,26 @@ lizardfs_master_notify() {
 	ocf_log debug "Received $type_op notification"
 	lizardfs_master_monitor
 	if [ $? -eq $OCF_SUCCESS ] ; then
-		# We're a shadow master node
-		ocf_log debug "We're a shadow master node"
+		msg="We're a shadow master node" # We're a shadow master node
+		ocf_log debug "$msg" ; test $debug && ocf_log notice "$msg"
 		case $type_op in
 			pre-promote)
 				# Start replicating from the new master
 				local new_master=$OCF_RESKEY_CRM_meta_notify_promote_uname
-				ocf_log debug "Changing master to $new_master"
+				msg="Changing master to $new_master"
+				ocf_log debug "$msg" ; test $debug && ocf_log notice "$msg"
 				# TODO
 				# call:
 				# lizardfs-admin force-reconnet ${host} ${port}
 			;;
 			*)
-				ocf_log debug "Notify type_op: $type_op"
+				msg="Notify type_op: $type_op"
+				ocf_log debug "$msg" ; test $debug && ocf_log notice "$msg"
 			;;
 		esac
 	else
-		ocf_log debug "lizardfs_master_monitor returned $?"
+		msg="lizardfs_master_monitor returned $?"
+		ocf_log debug "$msg" ; test $debug && ocf_log notice "$msg"
 	fi
 
 	return $OCF_SUCCESS
@@ -327,26 +370,31 @@ lizardfs_master_demote() {
 	lizardfs_master_monitor
 	case $? in
 		$OCF_RUNNING_MASTER)
-			ocf_log debug "LizardFS metadata server running as master, demoting"
-			ocf_run lizardfs_admin_quick_stop && unlink "${master_lock}" # May refuse if there are no shadows present, but that is ok
-			touch $debug_state_change_cfg/lfs-`date +\%Y\%m\%d.\%H\%M\%S`-Demote
+			# Node may refuse to quickly stop if there are no shadows present, but that is ok
+			msg="LizardFS metadata server running as master, demoting"
+			ocf_log debug "$msg" ; test $debug && ocf_log notice "$msg"
+	test $debug && touch $debug_state_change_logs/lfs-`date +\%Y\%m\%d.\%H\%M\%S`-Demote
+			ocf_run lizardfs_admin_quick_stop && unlink "${master_lock}"
 		;;
 		$OCF_SUCCESS)
-			ocf_log info "LizardFS metadata server already a shadow master"
+			msg="LizardFS metadata server already a shadow master"
+			ocf_log info "$msg" ; test $debug && ocf_log notice "$msg"
 			return $OCF_SUCCESS
 		;;
 		*)
-			ocf_log error \
-				"LizardFS metadata server not running, not a valid target for demotion"
+			msg="LizardFS metadata server not running, not a valid target for demotion"
+			ocf_log error "$msg" ; test $debug && ocf_log notice "$msg"
 			return $OCF_ERR_GENERIC
 		;;
 	esac
 
-# Do not bother to start the shadow again, trying to do so just causes the demotion to fail.
-	return $OCF_SUCCESS # so return now.
+# Do not bother to start the shadow again, trying to do so just causes the demotion operation to fail.
+	return $OCF_SUCCESS # so return right now instead
 # Perhaps we could call the lizardfs_master_start_shadow function with more success
-	if ! ocf_run lizardfs_master start shadow ; then # This was originally a restart which does not make sense if we just stopped.
-		ocf_log error "Failed to start shadow master, demotion failed"
+# The following was originally a restart which does not make sense if we had just stopped.
+	if ! ocf_run lizardfs_master start shadow ; then
+		msg="Failed to start shadow master, demotion failed"
+		ocf_log error "$msg" ; test $debug && ocf_log notice "$msg"
 		return $OCF_ERR_GENERIC
 	fi
 
@@ -371,29 +419,36 @@ lizardfs_probe() {
 	else
 		host=$matocl_host
 	fi
-# Error: Can't connect to 127.0.0.1:9421: ENOTCONN (Transport endpoint is not connected) ##### While stopping shadow master, stopping initial master, or starting initial master
-# Error: Can't read data from socket: timeout ##### While starting shadow master and reintegrating new metadata received from master
-# Send errors to stdin so we can use them to determin status of service which is not directly responding to the network probes
+# Error: Can't connect to 127.0.0.1:9421: ENOTCONN (Transport endpoint is not connected)
+## While stopping shadow master, stopping initial master, or starting initial master.
+# Error: Can't read data from socket: timeout
+## While starting shadow master and reintegrating new metadata received from master.
+# Send errors to stdin so we can determine status of service which is not responding to network probes:
 	probe_results=$(lizardfs-admin metadataserver-status --porcelain "${host}" "$matocl_port" 2>&1)
         ret=$?
-        if [ $ret -eq 0 ] ; then # exited clean, just return the results
+        if [ $ret -eq 0 ] ; then # exited clean so just return the results
 		echo "$probe_results"
-	else # existed with an error, making some reasonable assumptions
-		if   [[ "$probe_results" =~ "ENOTCONN (Transport endpoint is not connected)" ]] && [[ ! -z `pgrep -f "initial-personality=shadow start"` ]] ; then
+	else # existed with an error so trying to making some reasonable assumptions
+		if   [[ "$probe_results" =~ "ENOTCONN (Transport endpoint is not connected)" ]]\
+		 && [[ ! -z `pgrep -f "initial-personality=shadow start"` ]] ; then
 			echo -e "shadow\tstopping"
-# Can not rely on checking for recent file activity...
+# Can not rely on checking for recent file activity but considered it:
 #		elif [ ! -z `find ${data_dir}/ -mmin -1`    ] ; then # Watch for any 1 minute or newer files
 #		elif [ ! -z `find ${data_dir}/ -mmin -0.02` ] ; then # Watch for any ~1second or newer files
-		elif [[ "$probe_results" =~ "ENOTCONN (Transport endpoint is not connected)" ]] && [[ ! -z `pgrep -f "initial-personality=master start"` ]] ; then
+		elif [[ "$probe_results" =~ "ENOTCONN (Transport endpoint is not connected)" ]]\
+		 && [[ ! -z `pgrep -f "initial-personality=master start"` ]] ; then
 			echo -e "master\tstopping"
-# Can not determine the difference between stopping and starting initial master service, which is fine for now, both are valid.
+# Can not determine the difference between stopping and starting initial master service.
+# It is not a problem that we can not tell them apart, both are valid states which we wait on.
 #			echo -e "master\tstarting"
-		elif [[ "$probe_results" =~ "read data from socket: timeout" ]] && [[ ! -z `pgrep -f "initial-personality=shadow start"` ]] ; then
+		elif [[ "$probe_results" =~ "read data from socket: timeout" ]]\
+		 && [[ ! -z `pgrep -f "initial-personality=shadow start"` ]] ; then
 			echo -e "shadow\tsyncing"
 #		elif [[ ! -z `pgrep -f "initial-personality=shadow start"` ]] ; then
 #			echo -e "shadow\tsyncing"
-#		elif [[ "$probe_results" =~ "connection failed, error: ECONNREFUSED (Connection refused)" ]] && [[ ! -z `pgrep -f "initial-personality=shadow start"` ]] ; then
-#				ocf_log error "##### mfsmetarestore -a ; crm resource cleanup lizardfs-ms # to attempt to cleanup the metadata and clear errors."
+#		elif [[ "$probe_results" =~ "connection failed, error: ECONNREFUSED (Connection refused)" ]]\
+#		 && [[ ! -z `pgrep -f "initial-personality=shadow start"` ]] ; then
+#			ocf_log error "##### mfsmetarestore -a ; crm resource cleanup lizardfs-ms"
 #			echo -e "master\tunclean"
 ## Attempting to catch the quick stopped master which can only become a shadow or would require mfsmetarestore -a
 		else
@@ -406,7 +461,9 @@ lizardfs_admin_quick_stop() {
 	# Stop metadata server without saving metadata to file
 	echo -n "${admin_password}" | \
 		lizardfs-admin stop-master-without-saving-metadata "${matocl_host}" "$matocl_port"
-	touch $debug_state_change_cfg/lfs-`date +\%Y\%m\%d.\%H\%M\%S`-QStop
+	msg="LizardFS metadata server quickly stopping."
+	ocf_log debug "$msg" ; test $debug && ocf_log notice "$msg"
+	test $debug && touch $debug_state_change_logs/lfs-`date +\%Y\%m\%d.\%H\%M\%S`-QStop
 }
 
 update_master_score() {
@@ -414,7 +471,8 @@ update_master_score() {
 }
 
 set_metadata_version() {
-	ocf_log debug "LizardFS: setting cluster metadata version: ${1}"
+	msg="LizardFS: setting cluster metadata version: ${1}"
+	ocf_log debug "$msg" ; test $debug && ocf_log notice "$msg"
 	ocf_run ${HA_SBIN_DIR}/crm_attribute --lifetime=forever --type=crm_config --name=${metadata_version_attribute_name} --update="${1}"
 }
 
@@ -440,7 +498,8 @@ lizardfs_master_monitor() {
 		# master
 		probe_result=$(lizardfs_probe)
 		if [ $? -ne 0 ] ; then
-			ocf_log err "failed to query LizardFS master status"
+			msg="failed to query LizardFS master status"
+			ocf_log err "$msg" ; test $debug && ocf_log notice "$msg"
 			return $OCF_ERR_GENERIC
 		fi
 		local personality=$(echo "$probe_result" | cut -f1)
@@ -449,30 +508,35 @@ lizardfs_master_monitor() {
 		promote_mode="prevent"
 		case "$personality/$connection" in
 			master/running)
-				ocf_log debug "running in master mode"
+				msg="running in master mode"
+				ocf_log debug "$msg" ; test $debug && ocf_log notice "$msg"
 				update_master_score ${score_master}
 				set_metadata_version "${metadata_version}"
 				return $OCF_RUNNING_MASTER
 			;;
 			master/stopping)
-				ocf_log debug "running in master mode and stopping or starting."
+				msg="running in master mode and stopping or starting."
+				ocf_log debug "$msg" ; test $debug && ocf_log notice "$msg"
 				update_master_score ${score_shadow_no_metadata}
 				return $OCF_RUNNING_MASTER
 #				return $OCF_SUCCESS
 			;;
 #			master/starting)
-#				ocf_log debug "running in master mode starting up."
+#				msg="running in master mode starting up."
+#				ocf_log debug "$msg" ; test $debug && ocf_log notice "$msg"
 #				update_master_score ${score_shadow_no_metadata}
 #				return $OCF_SUCCESS
 #			;;
 			shadow/stopping)
-				ocf_log debug "running in shadow mode and stopping."
+				msg="running in shadow mode and stopping."
+				ocf_log debug "$msg" ; test $debug && ocf_log notice "$msg"
 				# Do not promote shadow if it is shutting down.
 				update_master_score ${score_shadow_no_metadata}
 				return $OCF_SUCCESS
 			;;
 			shadow/syncing)
-				ocf_log debug "running in shadow mode, syncing with master."
+				msg="running in shadow mode, syncing with master."
+				ocf_log debug "$msg" ; test $debug && ocf_log notice "$msg"
 				# Do not promote shadow which is syncing up to the master during startup
 				update_master_score ${score_shadow_no_metadata}
 				return $OCF_SUCCESS
@@ -480,7 +544,8 @@ lizardfs_master_monitor() {
 			shadow/connected|shadow/disconnected)
 				local cluster_metadata_version=$(get_metadata_version)
 				if [[ ( $? != 0 ) || ( ${cluster_metadata_version} == "" ) ]] ; then
-					ocf_log error "Failed to obtain metadata version from cluster."
+					msg="Failed to obtain metadata version from cluster."
+					ocf_log error "$msg" ; test $debug && ocf_log notice "$msg"
 					return $OCF_ERR_GENERIC
 				fi
 				if [[ ${metadata_version} -gt 0 ]] ; then
@@ -490,7 +555,8 @@ lizardfs_master_monitor() {
 					local local_metadata_version=$(get_metadata_version_from_file)
 				fi
 				if [ ${local_metadata_version} -ge ${cluster_metadata_version} ] ; then
-					ocf_log debug "running in shadow mode, have latest metadata: ${local_metadata_version}"
+					msg="running in shadow mode, have latest metadata: ${local_metadata_version}"
+					ocf_log debug "$msg" ; test $debug && ocf_log notice "$msg"
 					update_master_score ${score_shadow_lastest}
 					if [[ $in_memory ]] ; then
 						promote_mode="reload"
@@ -498,32 +564,41 @@ lizardfs_master_monitor() {
 						promote_mode="restart"
 					fi
 				elif [[ ${local_metadata_version} -gt 0 && ${in_memory} ]] ; then
-					ocf_log debug "running in shadow mode, latest metadata is not available: ${local_metadata_version} < ${cluster_metadata_version}"
+					msg="running in shadow mode, latest metadata is not available: ${local_metadata_version} < ${cluster_metadata_version}"
+					ocf_log debug "$msg" ; test $debug && ocf_log notice "$msg"
 					update_master_score ${score_shadow_connected}
 					promote_mode="reload"
 				else
-					ocf_log debug "running in shadow mode, no metadata."
+					msg="running in shadow mode, no metadata."
+					ocf_log debug "$msg" ; test $debug && ocf_log notice "$msg"
 					# Do not promote shadow with no metadata!
 					update_master_score ${score_shadow_no_metadata}
 				fi
 				return $OCF_SUCCESS
 			;;
 			*)
-				ocf_log err \
-			    "unexpected output from lizardfs-admin: $probe_result"
+				msg="unexpected output from lizardfs-admin: $probe_result"
+				ocf_log err "$msg" ; test $debug && ocf_log notice "$msg"
 				return $OCF_ERR_GENERIC
 			;;
 		esac
 	elif [ $ret -eq 1 ] ; then
 		if [ ! -e "$master_lock" ] ; then
-			ocf_log debug "LizardFS metadata server not running (clean)."
+			msg="LizardFS metadata server not running (clean)."
+			ocf_log debug "$msg" ; test $debug && ocf_log notice "$msg"
 			return $OCF_NOT_RUNNING
 		else
-	    ocf_log warn "LizardFS metadata server has failed"
+			msg="LizardFS metadata server has failed"
+			ocf_log warn "$msg" ; test $debug && ocf_log notice "$msg"
+ocf_log error "#####"
+ocf_log error "##### This node may have crashed, Try: rm ${master_lock} && crm resource cleanup lizardfs-ms"
+ocf_log error "#####"
+#unlink "${master_lock}"
 			return $OCF_FAILED_MASTER
 		fi
 	else
-		ocf_log err "error checking if master is running"
+		msg="error checking if master is running"
+		ocf_log err "$msg" ; test $debug && ocf_log notice "$msg"
 		return $OCF_ERR_GENERIC
 	fi
 }
@@ -535,16 +610,18 @@ lizardfs_master_reload() {
 	lizardfs_master_monitor
 	case $? in
 		$OCF_RUNNING_MASTER|$OCF_SUCCESS)
-			ocf_log debug "reloading LizardFS metadata server configuration"
+			msg="reloading LizardFS metadata server configuration"
+			ocf_log debug "$msg" ; test $debug && ocf_log notice "$msg"
+			test $debug && touch $debug_state_change_logs/lfs-`date +\%Y\%m\%d.\%H\%M\%S`-Reload
 			if ocf_run lizardfs_master reload ; then
-				touch $debug_state_change_cfg/lfs-`date +\%Y\%m\%d.\%H\%M\%S`-Reload
 				return $OCF_SUCCESS
 			else
 				return $OCF_ERR_GENERIC
 			fi
 		;;
 		*)
-			ocf_log error "no process running to reload"
+			msg="no process running to reload"
+			ocf_log error "$msg" ; test $debug && ocf_log notice "$msg"
 			return $OCF_ERR_GENERIC
 		;;
 	esac
@@ -578,21 +655,25 @@ lizardfs_master_validate() {
 	check_binary lizardfs-admin
 
 	if [[ "${failover_ip}" == "" ]] ; then
-		ocf_log err "MASTER_HOST not set in $OCF_RESKEY_master_cfg"
+		msg="MASTER_HOST not set in $OCF_RESKEY_master_cfg"
+		ocf_log err "$msg" ; test $debug && ocf_log notice "$msg"
 		exit $OCF_ERR_CONFIGURED
 	fi
 
 	if [ "x${admin_password}" = "x" ] ; then
-		ocf_log err "ADMIN_PASSWORD not set in $OCF_RESKEY_master_cfg"
+		msg="ADMIN_PASSWORD not set in $OCF_RESKEY_master_cfg"
+		ocf_log err "$msg" ; test $debug && ocf_log notice "$msg"
 		exit $OCF_ERR_CONFIGURED
 	fi
 
 	if ! [ -e "$OCF_RESKEY_master_cfg" ] ; then
-		ocf_log err "mfsmaster.cfg not found at $OCF_RESKEY_master_cfg"
+		msg="mfsmaster.cfg not found at $OCF_RESKEY_master_cfg"
+		ocf_log err "$msg" ; test $debug && ocf_log notice "$msg"
 		exit $OCF_ERR_CONFIGURED
 	fi
 	if ! [ -e "$exports_cfg" ] ; then
-		ocf_log err "mfsexports.cfg not found at $exports_cfg"
+		msg="mfsexports.cfg not found at $exports_cfg"
+		ocf_log err "$msg" ; test $debug && ocf_log notice "$msg"
 		exit $OCF_ERR_CONFIGURED
 	fi
 

--- a/src/ha-cluster/metadataserver.in
+++ b/src/ha-cluster/metadataserver.in
@@ -262,7 +262,14 @@ lizardfs_master_promote() {
 				fi
 			else
 				ocf_log error "promotion to master was prevented by monitor"
-				return $OCF_SUCCESS
+				ocf_log error "#####"
+				ocf_log error "##### If you would really like this node to become the initial master then you can run these commands:"
+				ocf_log error "##### mfsmetarestore -a ; crm resource cleanup lizardfs-ms # to attempt to cleanup the metadata and clear errors."
+				ocf_log error "##### If you do so you may be reverting to an old metedata set.  Be very sure this is what you want to do."
+				ocf_log error "##### If you just want this node to attempt to rejoin as a shadow then restart or use the cleanup command."
+				ocf_log error "#####"
+				return $OCF_ERR_PERM
+#				return $OCF_SUCCESS
 			fi
 
 			# Check that we are now succesfully a master
@@ -371,22 +378,26 @@ lizardfs_probe() {
         ret=$?
         if [ $ret -eq 0 ] ; then # exited clean, just return the results
 		echo "$probe_results"
-	else # existed with an error, make some assumptions
-		if   [[ "$probe_results" =~ "ENOTCONN" ]] && [[ ! -z `pgrep -f "initial-personality=shadow start"` ]] ; then
+	else # existed with an error, making some reasonable assumptions
+		if   [[ "$probe_results" =~ "ENOTCONN (Transport endpoint is not connected)" ]] && [[ ! -z `pgrep -f "initial-personality=shadow start"` ]] ; then
 			echo -e "shadow\tstopping"
-# Can not rely on checking for recent file activity.
+# Can not rely on checking for recent file activity...
 #		elif [ ! -z `find ${data_dir}/ -mmin -1`    ] ; then # Watch for any 1 minute or newer files
 #		elif [ ! -z `find ${data_dir}/ -mmin -0.02` ] ; then # Watch for any ~1second or newer files
-		elif [[ "$probe_results" =~ "ENOTCONN" ]] && [[ ! -z `pgrep -f "initial-personality=master start"` ]] ; then
+		elif [[ "$probe_results" =~ "ENOTCONN (Transport endpoint is not connected)" ]] && [[ ! -z `pgrep -f "initial-personality=master start"` ]] ; then
 			echo -e "master\tstopping"
-# Can not determin the difference between stopping and starting master service.
+# Can not determine the difference between stopping and starting initial master service, which is fine for now, both are valid.
 #			echo -e "master\tstarting"
 		elif [[ "$probe_results" =~ "read data from socket: timeout" ]] && [[ ! -z `pgrep -f "initial-personality=shadow start"` ]] ; then
 			echo -e "shadow\tsyncing"
 #		elif [[ ! -z `pgrep -f "initial-personality=shadow start"` ]] ; then
 #			echo -e "shadow\tsyncing"
+#		elif [[ "$probe_results" =~ "connection failed, error: ECONNREFUSED (Connection refused)" ]] && [[ ! -z `pgrep -f "initial-personality=shadow start"` ]] ; then
+#				ocf_log error "##### mfsmetarestore -a ; crm resource cleanup lizardfs-ms # to attempt to cleanup the metadata and clear errors."
+#			echo -e "master\tunclean"
+## Attempting to catch the quick stopped master which can only become a shadow or would require mfsmetarestore -a
 		else
-			echo -e "shadow\tunknown"
+			echo -e "unknown\tunknown\t$probe_results"
 		fi
 	fi
 }
@@ -446,7 +457,8 @@ lizardfs_master_monitor() {
 			master/stopping)
 				ocf_log debug "running in master mode and stopping or starting."
 				update_master_score ${score_shadow_no_metadata}
-				return $OCF_SUCCESS
+				return $OCF_RUNNING_MASTER
+#				return $OCF_SUCCESS
 			;;
 #			master/starting)
 #				ocf_log debug "running in master mode starting up."
@@ -490,7 +502,7 @@ lizardfs_master_monitor() {
 					update_master_score ${score_shadow_connected}
 					promote_mode="reload"
 				else
-					ocf_log debug "running in shadow mode, no metadata"
+					ocf_log debug "running in shadow mode, no metadata."
 					# Do not promote shadow with no metadata!
 					update_master_score ${score_shadow_no_metadata}
 				fi

--- a/src/ha-cluster/metadataserver.in
+++ b/src/ha-cluster/metadataserver.in
@@ -386,8 +386,17 @@ lizardfs_master_monitor() {
 		# master
 		probe_result=$(lizardfs_probe)
 		if [ $? -ne 0 ] ; then
+# Failed to query via port.
+# But we might still be starting or stopping...
+# Check if we have a lock file before deciding our state
+		if [ -e "$master_lock" ] ; then
+			ocf_log debug "LizardFS metadata server might be starting or stopping."
+			update_master_score ${score_shadow_no_metadata}
+			return $OCF_RUNNING_MASTER
+		else
 			ocf_log err "failed to query LizardFS master status"
 			return $OCF_ERR_GENERIC
+		fi
 		fi
 		local personality=$(echo "$probe_result" | cut -f1)
 		local connection=$(echo "$probe_result" | cut -f2)
@@ -549,7 +558,7 @@ case "$1" in
 	reload)   lizardfs_master_reload;;
 	promote)  lizardfs_master_promote;;
 	demote)   lizardfs_master_demote;;
-	# notify)   lizardfs_master_notify;;
+	#notify)   lizardfs_master_notify;;
 	# We have already validated by now
 	validate-all) ;;
 	*)        usage; exit $OCF_ERR_UNIMPLEMENTED;;


### PR DESCRIPTION
Just Copy Pasting the master version I have to verify there are no changes before starting on my actual changesets.  This edit did resolve one bug with the exports_cfg which was the first thing preventing this from working as it.  It appears I have changes some variables to static, which can/should be reverted at a later time:
:sed -i 's%OCF_RESKEY_master_cfg_default=/etc%OCF_RESKEY_master_cfg_default=@ETC_PATH@%' $File
:sed -i 's%DATA_PATH = /var/lib/mfs%DATA_PATH = @DATA_PATH@%' $File
:sed -i 's%WORKING_USER = mfs%WORKING_USER = @DEFAULT_USER@%' $File
:sed -i 's%WORKING_USER = mfs@%WORKING_USER = @DEFAULT_GROUP@%' $File
:sed -i 's%exports_cfg=/etc%exports_cfg=@ETC_PATH@%' $File
